### PR TITLE
feat(core): add VineJS request validation (TODO-06)

### DIFF
--- a/digitaltwin-core/package.json
+++ b/digitaltwin-core/package.json
@@ -92,6 +92,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.850.0",
+    "@vinejs/vine": "^4.2.0",
     "bullmq": "^5.56.5",
     "cors": "^2.8.5",
     "ioredis": "^5.6.1",

--- a/digitaltwin-core/src/errors/index.ts
+++ b/digitaltwin-core/src/errors/index.ts
@@ -36,11 +36,11 @@ export abstract class DigitalTwinError extends Error {
 }
 
 /**
- * Validation error - invalid input data (400)
+ * Validation error - invalid input data (422 Unprocessable Entity)
  */
 export class ValidationError extends DigitalTwinError {
     readonly code = 'VALIDATION_ERROR' as const
-    readonly statusCode = 400 as const
+    readonly statusCode = 422 as const
 }
 
 /**

--- a/digitaltwin-core/src/index.ts
+++ b/digitaltwin-core/src/index.ts
@@ -54,6 +54,9 @@ export * from './auth/index.js'
 // Errors
 export * from './errors/index.js'
 
+// Validation
+export * from './validation/index.js'
+
 // Utilities
 export { Logger, LogLevel } from './utils/logger.js'
 export { safeAsync, tryAsync, safeCleanup, retryAsync } from './utils/safe_async.js'

--- a/digitaltwin-core/src/validation/index.ts
+++ b/digitaltwin-core/src/validation/index.ts
@@ -1,0 +1,23 @@
+// Validation schemas
+export {
+    paginationSchema,
+    idParamSchema,
+    assetUploadSchema,
+    assetUpdateSchema,
+    assetBatchUploadSchema,
+    customRecordCreateSchema,
+    customRecordUpdateSchema,
+    dateRangeQuerySchema,
+    // Pre-compiled validators
+    validatePagination,
+    validateIdParam,
+    validateAssetUpload,
+    validateAssetUpdate,
+    validateAssetBatchUpload,
+    validateCustomRecordCreate,
+    validateCustomRecordUpdate,
+    validateDateRangeQuery
+} from './schemas.js'
+
+// Validation helpers
+export { validateData, safeValidate, validateQuery, validateParams, vine } from './validate.js'

--- a/digitaltwin-core/src/validation/schemas.ts
+++ b/digitaltwin-core/src/validation/schemas.ts
@@ -1,0 +1,97 @@
+import vine from '@vinejs/vine'
+
+// ============================================
+// Common schemas
+// ============================================
+
+/**
+ * Pagination query parameters schema
+ */
+export const paginationSchema = vine.object({
+    limit: vine.number().positive().max(1000).optional(),
+    offset: vine.number().min(0).optional()
+})
+
+/**
+ * ID parameter schema
+ */
+export const idParamSchema = vine.object({
+    id: vine.number().positive()
+})
+
+// ============================================
+// Assets Manager schemas
+// ============================================
+
+/**
+ * Asset upload body schema
+ */
+export const assetUploadSchema = vine.object({
+    description: vine.string().maxLength(1000).optional(),
+    source: vine.string().url().optional(),
+    is_public: vine.boolean().optional()
+})
+
+/**
+ * Asset update body schema
+ */
+export const assetUpdateSchema = vine.object({
+    description: vine.string().maxLength(1000).optional(),
+    source: vine.string().url().optional(),
+    is_public: vine.boolean().optional()
+})
+
+/**
+ * Batch upload body schema
+ */
+export const assetBatchUploadSchema = vine.object({
+    assets: vine
+        .array(
+            vine.object({
+                description: vine.string().maxLength(1000).optional(),
+                source: vine.string().url().optional(),
+                is_public: vine.boolean().optional()
+            })
+        )
+        .optional()
+})
+
+// ============================================
+// Custom Table Manager schemas
+// ============================================
+
+/**
+ * Custom record create schema (allows passthrough for dynamic fields)
+ */
+export const customRecordCreateSchema = vine.object({}).allowUnknownProperties()
+
+/**
+ * Custom record update schema
+ */
+export const customRecordUpdateSchema = vine.object({}).allowUnknownProperties()
+
+// ============================================
+// Query parameter schemas
+// ============================================
+
+/**
+ * Date range query schema
+ */
+export const dateRangeQuerySchema = vine.object({
+    startDate: vine.string().optional(),
+    endDate: vine.string().optional(),
+    limit: vine.number().positive().max(1000).optional()
+})
+
+// ============================================
+// Compiled validators (for performance)
+// ============================================
+
+export const validatePagination = vine.compile(paginationSchema)
+export const validateIdParam = vine.compile(idParamSchema)
+export const validateAssetUpload = vine.compile(assetUploadSchema)
+export const validateAssetUpdate = vine.compile(assetUpdateSchema)
+export const validateAssetBatchUpload = vine.compile(assetBatchUploadSchema)
+export const validateCustomRecordCreate = vine.compile(customRecordCreateSchema)
+export const validateCustomRecordUpdate = vine.compile(customRecordUpdateSchema)
+export const validateDateRangeQuery = vine.compile(dateRangeQuerySchema)

--- a/digitaltwin-core/src/validation/validate.ts
+++ b/digitaltwin-core/src/validation/validate.ts
@@ -1,0 +1,127 @@
+import vine, { errors } from '@vinejs/vine'
+import { ValidationError } from '../errors/index.js'
+
+type AnyValidator = { validate: (data: unknown) => Promise<unknown> }
+
+/**
+ * Validates data using a pre-compiled VineJS validator.
+ * @param validator - Compiled VineJS validator
+ * @param data - Data to validate
+ * @param context - Optional context for error messages
+ * @returns Validated and typed data
+ * @throws ValidationError if validation fails
+ */
+export async function validateData<T>(validator: AnyValidator, data: unknown, context?: string): Promise<T> {
+    try {
+        const result = await validator.validate(data)
+        return result as T
+    } catch (error) {
+        if (error instanceof errors.E_VALIDATION_ERROR) {
+            const messages = error.messages
+                .map((e: { field: string; message: string }) => `${e.field}: ${e.message}`)
+                .join(', ')
+
+            throw new ValidationError(context ? `${context}: ${messages}` : messages, {
+                errors: error.messages
+            })
+        }
+        throw error
+    }
+}
+
+/**
+ * Validates data and returns result without throwing.
+ * Useful for optional validation or when you want to handle errors manually.
+ * @param validator - Compiled VineJS validator
+ * @param data - Data to validate
+ * @returns Object with success status, data (if valid), or errors (if invalid)
+ */
+export async function safeValidate<T>(
+    validator: AnyValidator,
+    data: unknown
+): Promise<{ success: true; data: T } | { success: false; errors: Array<{ field: string; message: string }> }> {
+    try {
+        const validated = await validator.validate(data)
+        return { success: true, data: validated as T }
+    } catch (error) {
+        if (error instanceof errors.E_VALIDATION_ERROR) {
+            return { success: false, errors: error.messages }
+        }
+        throw error
+    }
+}
+
+/**
+ * Validates query parameters, coercing string values to appropriate types.
+ * Query params from Express are always strings, so we need to convert them.
+ * @param validator - Compiled VineJS validator
+ * @param query - Query object from Express request
+ * @param context - Optional context for error messages
+ * @returns Validated and typed query parameters
+ */
+export async function validateQuery<T>(
+    validator: AnyValidator,
+    query: Record<string, unknown>,
+    context?: string
+): Promise<T> {
+    // Coerce query string values to appropriate types
+    const coerced: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(query)) {
+        if (value === undefined || value === '') {
+            continue // Skip empty values
+        }
+
+        if (typeof value === 'string') {
+            // Try to coerce to number
+            const num = Number(value)
+            if (!isNaN(num) && value.trim() !== '') {
+                coerced[key] = num
+            }
+            // Try to coerce to boolean
+            else if (value.toLowerCase() === 'true') {
+                coerced[key] = true
+            } else if (value.toLowerCase() === 'false') {
+                coerced[key] = false
+            } else {
+                coerced[key] = value
+            }
+        } else {
+            coerced[key] = value
+        }
+    }
+
+    return validateData(validator, coerced, context)
+}
+
+/**
+ * Validates path parameters (e.g., :id in routes).
+ * @param validator - Compiled VineJS validator
+ * @param params - Params object from Express request
+ * @param context - Optional context for error messages
+ * @returns Validated and typed parameters
+ */
+export async function validateParams<T>(
+    validator: AnyValidator,
+    params: Record<string, string>,
+    context?: string
+): Promise<T> {
+    // Coerce param values (always strings from Express)
+    const coerced: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined) continue
+
+        const num = Number(value)
+        if (!isNaN(num) && value.trim() !== '') {
+            coerced[key] = num
+        } else {
+            coerced[key] = value
+        }
+    }
+
+    return validateData(validator, coerced, context)
+}
+
+// Re-export vine for custom schema creation
+export { vine }

--- a/digitaltwin-core/tests/components/custom_table_manager.spec.ts
+++ b/digitaltwin-core/tests/components/custom_table_manager.spec.ts
@@ -383,7 +383,7 @@ test.group('CustomTableManager endpoints', (group) => {
             params: {}
         })
 
-        assert.equal(response.status, 400)
+        assert.equal(response.status, 422) // ValidationError returns 422 Unprocessable Entity
     })
 
     test('handleGetById should return 404 for non-existent record', async ({ assert }) => {

--- a/digitaltwin-core/tests/errors/errors.spec.ts
+++ b/digitaltwin-core/tests/errors/errors.spec.ts
@@ -20,7 +20,7 @@ test.group('Custom Error Classes', () => {
         const error = new ValidationError('Invalid input')
 
         assert.equal(error.code, 'VALIDATION_ERROR')
-        assert.equal(error.statusCode, 400)
+        assert.equal(error.statusCode, 422)
         assert.equal(error.message, 'Invalid input')
         assert.equal(error.name, 'ValidationError')
         assert.instanceOf(error.timestamp, Date)

--- a/digitaltwin-core/tests/validation/validation.spec.ts
+++ b/digitaltwin-core/tests/validation/validation.spec.ts
@@ -1,0 +1,315 @@
+import { test } from '@japa/runner'
+import {
+    validateData,
+    safeValidate,
+    validateQuery,
+    validateParams,
+    validatePagination,
+    validateIdParam,
+    validateAssetUpload,
+    validateAssetUpdate,
+    validateAssetBatchUpload
+} from '../../src/validation/index.js'
+import { ValidationError } from '../../src/errors/index.js'
+
+test.group('validateData', () => {
+    test('validates correct data and returns typed result', async ({ assert }) => {
+        const data = { id: 123 }
+        const result = await validateData<{ id: number }>(validateIdParam, data)
+
+        assert.equal(result.id, 123)
+    })
+
+    test('throws ValidationError for invalid data', async ({ assert }) => {
+        const data = { id: 'not-a-number' }
+
+        try {
+            await validateData(validateIdParam, data)
+            assert.fail('Should have thrown ValidationError')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+        }
+    })
+
+    test('includes context in error message', async ({ assert }) => {
+        const data = { id: -5 }
+
+        try {
+            await validateData(validateIdParam, data, 'Asset ID')
+            assert.fail('Should have thrown')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+            assert.include((error as ValidationError).message, 'Asset ID')
+        }
+    })
+})
+
+test.group('safeValidate', () => {
+    test('returns success: true for valid data', async ({ assert }) => {
+        const data = { id: 42 }
+        const result = await safeValidate<{ id: number }>(validateIdParam, data)
+
+        assert.isTrue(result.success)
+        if (result.success) {
+            assert.equal(result.data.id, 42)
+        }
+    })
+
+    test('returns success: false for invalid data', async ({ assert }) => {
+        const data = { id: 'invalid' }
+        const result = await safeValidate(validateIdParam, data)
+
+        assert.isFalse(result.success)
+        if (!result.success) {
+            assert.isArray(result.errors)
+            assert.isTrue(result.errors.length > 0)
+        }
+    })
+
+    test('returns error details for validation failures', async ({ assert }) => {
+        const data = { id: -100 }
+        const result = await safeValidate(validateIdParam, data)
+
+        assert.isFalse(result.success)
+        if (!result.success) {
+            assert.isTrue(result.errors.some(e => e.field === 'id'))
+        }
+    })
+})
+
+test.group('validateQuery', () => {
+    test('coerces string numbers to numbers', async ({ assert }) => {
+        const query = { limit: '50', offset: '10' }
+        const result = await validateQuery<{ limit?: number; offset?: number }>(validatePagination, query)
+
+        assert.equal(result.limit, 50)
+        assert.equal(result.offset, 10)
+    })
+
+    test('coerces string booleans to booleans', async ({ assert }) => {
+        const query = { is_public: 'true' }
+        const result = await validateQuery<{ is_public?: boolean }>(validateAssetUpload, query)
+
+        assert.strictEqual(result.is_public, true)
+    })
+
+    test('skips empty string values', async ({ assert }) => {
+        const query = { limit: '', offset: '5' }
+        const result = await validateQuery<{ limit?: number; offset?: number }>(validatePagination, query)
+
+        assert.isUndefined(result.limit)
+        assert.equal(result.offset, 5)
+    })
+
+    test('throws ValidationError for invalid query params', async ({ assert }) => {
+        const query = { limit: '-50' }
+
+        try {
+            await validateQuery(validatePagination, query)
+            assert.fail('Should have thrown ValidationError')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+        }
+    })
+})
+
+test.group('validateParams', () => {
+    test('coerces string id to number', async ({ assert }) => {
+        const params = { id: '123' }
+        const result = await validateParams<{ id: number }>(validateIdParam, params)
+
+        assert.equal(result.id, 123)
+    })
+
+    test('throws ValidationError for non-numeric id', async ({ assert }) => {
+        const params = { id: 'abc' }
+
+        try {
+            await validateParams(validateIdParam, params)
+            assert.fail('Should have thrown ValidationError')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+        }
+    })
+
+    test('throws ValidationError for negative id', async ({ assert }) => {
+        const params = { id: '-1' }
+
+        try {
+            await validateParams(validateIdParam, params)
+            assert.fail('Should have thrown ValidationError')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+        }
+    })
+})
+
+test.group('Pagination Schema', () => {
+    test('accepts valid pagination', async ({ assert }) => {
+        const data = { limit: 100, offset: 0 }
+        const result = await validateData<{ limit?: number; offset?: number }>(validatePagination, data)
+
+        assert.equal(result.limit, 100)
+        assert.equal(result.offset, 0)
+    })
+
+    test('accepts empty pagination (all optional)', async ({ assert }) => {
+        const data = {}
+        const result = await validateData<{ limit?: number; offset?: number }>(validatePagination, data)
+
+        assert.isUndefined(result.limit)
+        assert.isUndefined(result.offset)
+    })
+
+    test('rejects limit exceeding max (1000)', async ({ assert }) => {
+        const data = { limit: 2000 }
+
+        try {
+            await validateData(validatePagination, data)
+            assert.fail('Should have thrown ValidationError')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+        }
+    })
+
+    test('rejects negative limit', async ({ assert }) => {
+        const data = { limit: -10 }
+
+        try {
+            await validateData(validatePagination, data)
+            assert.fail('Should have thrown ValidationError')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+        }
+    })
+
+    test('rejects negative offset', async ({ assert }) => {
+        const data = { offset: -5 }
+
+        try {
+            await validateData(validatePagination, data)
+            assert.fail('Should have thrown ValidationError')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+        }
+    })
+})
+
+test.group('ID Param Schema', () => {
+    test('accepts positive integer id', async ({ assert }) => {
+        const data = { id: 1 }
+        const result = await validateData<{ id: number }>(validateIdParam, data)
+
+        assert.equal(result.id, 1)
+    })
+
+    test('rejects zero id', async ({ assert }) => {
+        const data = { id: 0 }
+
+        try {
+            await validateData(validateIdParam, data)
+            assert.fail('Should have thrown ValidationError')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+        }
+    })
+
+    test('rejects missing id', async ({ assert }) => {
+        const data = {}
+
+        try {
+            await validateData(validateIdParam, data)
+            assert.fail('Should have thrown ValidationError')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+        }
+    })
+})
+
+test.group('Asset Upload Schema', () => {
+    test('accepts valid asset upload data', async ({ assert }) => {
+        const data = {
+            description: 'Test asset',
+            source: 'https://example.com/source',
+            is_public: true
+        }
+        const result = await validateData<{
+            description?: string
+            source?: string
+            is_public?: boolean
+        }>(validateAssetUpload, data)
+
+        assert.equal(result.description, 'Test asset')
+        assert.equal(result.source, 'https://example.com/source')
+        assert.isTrue(result.is_public)
+    })
+
+    test('accepts empty data (all optional)', async ({ assert }) => {
+        const data = {}
+        const result = await validateData(validateAssetUpload, data)
+
+        assert.deepEqual(result, {})
+    })
+
+    test('rejects description exceeding max length', async ({ assert }) => {
+        const data = { description: 'a'.repeat(1001) }
+
+        try {
+            await validateData(validateAssetUpload, data)
+            assert.fail('Should have thrown ValidationError')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+        }
+    })
+
+    test('rejects invalid URL for source', async ({ assert }) => {
+        const data = { source: 'not-a-valid-url' }
+
+        try {
+            await validateData(validateAssetUpload, data)
+            assert.fail('Should have thrown ValidationError')
+        } catch (error) {
+            assert.instanceOf(error, ValidationError)
+        }
+    })
+})
+
+test.group('Asset Update Schema', () => {
+    test('accepts partial update', async ({ assert }) => {
+        const data = { description: 'Updated description' }
+        const result = await validateData<{ description?: string }>(validateAssetUpdate, data)
+
+        assert.equal(result.description, 'Updated description')
+    })
+
+    test('accepts visibility update only', async ({ assert }) => {
+        const data = { is_public: false }
+        const result = await validateData<{ is_public?: boolean }>(validateAssetUpdate, data)
+
+        assert.isFalse(result.is_public)
+    })
+})
+
+test.group('Asset Batch Upload Schema', () => {
+    test('accepts batch upload data', async ({ assert }) => {
+        const data = {
+            assets: [
+                { description: 'Asset 1', source: 'https://example.com/1' },
+                { description: 'Asset 2', is_public: false }
+            ]
+        }
+        const result = await validateData<{
+            assets?: Array<{ description?: string; source?: string; is_public?: boolean }>
+        }>(validateAssetBatchUpload, data)
+
+        assert.isArray(result.assets)
+        assert.lengthOf(result.assets!, 2)
+    })
+
+    test('accepts empty batch (assets optional)', async ({ assert }) => {
+        const data = {}
+        const result = await validateData(validateAssetBatchUpload, data)
+
+        assert.isUndefined(result.assets)
+    })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.850.0
         version: 3.968.0
+      '@vinejs/vine':
+        specifier: ^4.2.0
+        version: 4.2.0
       better-sqlite3:
         specifier: ^12.2.0
         version: 12.6.0
@@ -962,6 +965,9 @@ packages:
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@testcontainers/redis@11.11.0':
     resolution: {integrity: sha512-IaDPNd1jRkshwJ69D7Nc3OTt5QQG1d4G1TZILSQ7gAVr4OqAJxoA9pV73ZvKIF/8LwxDDg136ApPlU9PcFtIKg==}
 
@@ -1089,6 +1095,9 @@ packages:
   '@types/uuid@10.0.0':
     resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
+  '@types/validator@13.15.10':
+    resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
+
   '@typescript-eslint/eslint-plugin@8.53.0':
     resolution: {integrity: sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1147,6 +1156,14 @@ packages:
   '@typescript-eslint/visitor-keys@8.53.0':
     resolution: {integrity: sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vinejs/compiler@4.1.2':
+    resolution: {integrity: sha512-Cg5EE6wft/kYlxDti577WVCIXNb0FFsXdR+aphz1E+KXoc0pLRa4HbZydHu0bCDW5iPuRZujctmRpzEoA7/Nag==}
+    engines: {node: '>=18.0.0'}
+
+  '@vinejs/vine@4.2.0':
+    resolution: {integrity: sha512-pb6iC9jX7w42nEvKUUWOWcnF1qZDPvmEFjgHCO1hwbO9nOrFw6e3JpYiZNoJGloywXeoE1FgC4JkKk9fdNSdow==}
+    engines: {node: '>=18.16.0'}
 
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -1390,6 +1407,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase@9.0.0:
+    resolution: {integrity: sha512-TO9xmyXTZ9HUHI8M1OnvExxYB0eYVS/1e5s7IDMTAoIcwUd+aNcFODs6Xk83mobk0velyHFQgA1yIrvYc6wclw==}
+    engines: {node: '>=20'}
+
   case-anything@3.1.2:
     resolution: {integrity: sha512-wljhAjDDIv/hM2FzgJnYQg90AWmZMNtESCjTeLH680qTzdo0nErlCxOmgzgX4ZsZAtIvqHyD87ES8QyriXB+BQ==}
     engines: {node: '>=18'}
@@ -1533,6 +1554,9 @@ packages:
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
+  dayjs@1.11.19:
+    resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
+
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -1576,6 +1600,9 @@ packages:
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   docker-compose@1.3.0:
     resolution: {integrity: sha512-7Gevk/5eGD50+eMD+XDnFnOrruFkL0kSd7jEG4cjmqweDSUhB7i0g8is/nBdVpl+Bx338SqIB2GLKm32M+Vs6g==}
@@ -2366,6 +2393,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-url@8.1.1:
+    resolution: {integrity: sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==}
+    engines: {node: '>=14.16'}
+
   npmlog@6.0.2:
     resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -3027,6 +3058,10 @@ packages:
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  validator@13.15.26:
+    resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
+    engines: {node: '>= 0.10'}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -4329,6 +4364,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.14': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@testcontainers/redis@11.11.0':
     dependencies:
       testcontainers: 11.11.0
@@ -4492,6 +4529,8 @@ snapshots:
 
   '@types/uuid@10.0.0': {}
 
+  '@types/validator@13.15.10': {}
+
   '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -4582,6 +4621,21 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.53.0
       eslint-visitor-keys: 4.2.1
+
+  '@vinejs/compiler@4.1.2': {}
+
+  '@vinejs/vine@4.2.0':
+    dependencies:
+      '@poppinss/macroable': 1.1.0
+      '@poppinss/types': 1.2.1
+      '@standard-schema/spec': 1.1.0
+      '@types/validator': 13.15.10
+      '@vinejs/compiler': 4.1.2
+      camelcase: 9.0.0
+      dayjs: 1.11.19
+      dlv: 1.1.3
+      normalize-url: 8.1.1
+      validator: 13.15.26
 
   abbrev@1.1.1:
     optional: true
@@ -4856,6 +4910,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase@9.0.0: {}
+
   case-anything@3.1.2: {}
 
   chai@6.2.2: {}
@@ -4980,6 +5036,8 @@ snapshots:
 
   data-uri-to-buffer@2.0.2: {}
 
+  dayjs@1.11.19: {}
+
   debug@4.3.4:
     dependencies:
       ms: 2.1.2
@@ -5004,6 +5062,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   diff@4.0.2: {}
+
+  dlv@1.1.3: {}
 
   docker-compose@1.3.0:
     dependencies:
@@ -5854,6 +5914,8 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  normalize-url@8.1.1: {}
+
   npmlog@6.0.2:
     dependencies:
       are-we-there-yet: 3.0.1
@@ -6586,6 +6648,8 @@ snapshots:
   uuid@11.1.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
+
+  validator@13.15.26: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary
- Add VineJS validation module with pre-compiled schemas
- Integrate validation in AssetsManager and CustomTableManager
- ValidationError now returns 422 Unprocessable Entity
- Global error handler automatically uses correct status codes for DigitalTwinError

## Changes
- `src/validation/` - New validation module (schemas, helpers)
- `src/components/assets_manager.ts` - ID, body, pagination validation
- `src/components/custom_table_manager.ts` - ID, body validation  
- `src/errors/index.ts` - ValidationError.statusCode = 422
- `src/utils/http_responses.ts` - errorResponse() uses DigitalTwinError.statusCode

## Test plan
- [x] 29 new validation tests added
- [x] All 454 tests passing
- [x] Lint and format checks pass