### PR TITLE
test(core): replace meaningless assertions with actual behavior verif…

### DIFF
--- a/digitaltwin-core/tests/components/collector.spec.ts
+++ b/digitaltwin-core/tests/components/collector.spec.ts
@@ -243,13 +243,16 @@ test.group('Collector configuration', () => {
         assert.isTrue(parts.length >= 5)
     })
 
-    test('setDependencies should accept db and storage', ({ assert }) => {
+    test('setDependencies should enable collector to run successfully', async ({ assert }) => {
         const storage = new LocalStorageService('.test_deps')
         const db = new MockDatabaseAdapter({ storage })
         const collector = new DummyCollector()
 
-        // Should not throw
         collector.setDependencies(db, storage)
-        assert.isTrue(true)
+
+        // Verify dependencies are correctly set by performing an operation
+        const result = await collector.run()
+        assert.instanceOf(result, Buffer)
+        assert.isTrue(collector.collected)
     })
 })

--- a/digitaltwin-core/tests/components/tileset_manager.spec.ts
+++ b/digitaltwin-core/tests/components/tileset_manager.spec.ts
@@ -899,20 +899,41 @@ test.group('TilesetManager.getOpenAPISpec', () => {
     })
 })
 
+// Test subclass to verify uploadQueue is set
+class TestTilesetManagerWithQueueAccess extends TilesetManager {
+    getConfiguration(): AssetsManagerConfiguration {
+        return {
+            name: 'test-tilesets-queue',
+            description: 'Test tileset manager for queue testing',
+            contentType: 'application/json',
+            extension: '.zip',
+            endpoint: 'test-tilesets-queue'
+        }
+    }
+
+    hasUploadQueue(): boolean {
+        return this.uploadQueue !== null
+    }
+}
+
 test.group('TilesetManager.setUploadQueue', () => {
-    test('accepts upload queue', async ({ assert }) => {
-        const manager = new TestTilesetManager()
+    test('stores upload queue for async processing', async ({ assert }) => {
+        const manager = new TestTilesetManagerWithQueueAccess()
         const db = new MockDatabaseAdapter()
         const storage = new LocalStorageService('.test-queue')
         manager.setDependencies(db, storage)
+
+        // Initially no queue
+        assert.isFalse(manager.hasUploadQueue(), 'Queue should be null initially')
 
         // Mock queue
         const mockQueue = {
             add: async () => ({ id: 'job-1' })
         } as any
 
-        // Should not throw
         manager.setUploadQueue(mockQueue)
-        assert.isTrue(true)
+
+        // Queue should now be set
+        assert.isTrue(manager.hasUploadQueue(), 'Queue should be set after setUploadQueue')
     })
 })

--- a/digitaltwin-core/tests/engine/initializer.spec.ts
+++ b/digitaltwin-core/tests/engine/initializer.spec.ts
@@ -144,14 +144,24 @@ test.group('initializeComponents', () => {
     assert.equal(tablesCreatedCount, 2, 'Should create 2 missing tables')
   })
 
-  test('should handle empty components array', async ({ assert }) => {
+  test('should handle empty components array without throwing', async ({ assert }) => {
     const database = new MockDatabaseAdapter()
     const storage = new MockStorageService()
-    
-    // Should not throw any errors
-    await initializeComponents([], database, storage)
-    
-    assert.isTrue(true) // Test passes if no exception is thrown
+
+    // Track if any table operations were called
+    let tableCheckCount = 0
+    database.doesTableExists = async () => {
+      tableCheckCount++
+      return true
+    }
+
+    // Should complete without throwing
+    await assert.doesNotReject(
+      async () => initializeComponents([], database, storage)
+    )
+
+    // No table checks should have been performed for empty array
+    assert.equal(tableCheckCount, 0, 'No table checks should occur for empty components')
   })
 
   test('should handle mixed collector and harvester components', async ({ assert }) => {

--- a/digitaltwin-core/tests/engine/scheduler.spec.ts
+++ b/digitaltwin-core/tests/engine/scheduler.spec.ts
@@ -108,7 +108,11 @@ test.group('Scheduler with Redis container', (group) => {
     const workers = await scheduleComponents([collector, harvester], queueManager, true)
 
     assert.equal(workers.length, 3)
-    assert.isTrue(workers.every((w) => true))
+    // Verify each worker has the required methods
+    assert.isTrue(
+      workers.every((w) => typeof w.close === 'function'),
+      'All workers should have a close method'
+    )
 
     for (const worker of workers) {
       await worker.close()

--- a/digitaltwin-core/tests/engine/shutdown.spec.ts
+++ b/digitaltwin-core/tests/engine/shutdown.spec.ts
@@ -41,7 +41,7 @@ test.group('Graceful Shutdown', () => {
         assert.isBelow(duration, 50)
     })
 
-    test('setShutdownTimeout configures timeout', ({ assert }) => {
+    test('setShutdownTimeout accepts valid timeout values', ({ assert }) => {
         const db = new MockDatabaseAdapter()
         const storage = new MockStorageService()
 
@@ -50,9 +50,20 @@ test.group('Graceful Shutdown', () => {
             storage: storage
         })
 
-        // Should not throw
+        // Verify method exists and accepts various valid timeout values
+        assert.isFunction(engine.setShutdownTimeout)
+
+        // Should accept standard timeout
         engine.setShutdownTimeout(60000)
-        assert.isTrue(true)
+
+        // Should accept minimum reasonable timeout
+        engine.setShutdownTimeout(1000)
+
+        // Should accept longer timeout
+        engine.setShutdownTimeout(120000)
+
+        // Engine should still be functional after setting timeout
+        assert.isFalse(engine.isShuttingDown())
     })
 
     test('stop() cleans up resources without errors', async ({ assert }) => {


### PR DESCRIPTION
…ication

Fix 7 tests that used `assert.isTrue(true)` or similar patterns that don't actually test anything:

- collector.spec.ts: verify setDependencies enables run()
- shutdown.spec.ts: verify setShutdownTimeout accepts valid values
- initializer.spec.ts: verify empty array doesn't trigger table checks
- scheduler.spec.ts: verify workers have required close method
- tileset_manager.spec.ts: verify setUploadQueue stores the queue
- graceful_shutdown.spec.ts: verify signal handlers are registered