### PR TITLE
feat(ci): lint all packages + PostgreSQL integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,21 @@ jobs:
       matrix:
         node-version: [20.x, 22.x]
 
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,7 +48,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: pnpm --filter digitaltwin-core lint
+        run: pnpm lint
 
       - name: Build all packages
         run: pnpm build
@@ -47,3 +62,8 @@ jobs:
         run: pnpm test
         env:
           NODE_ENV: test
+          TEST_PG_HOST: localhost
+          TEST_PG_PORT: 5432
+          TEST_PG_USER: test
+          TEST_PG_PASSWORD: test
+          TEST_PG_DATABASE: test

--- a/create-digitaltwin/src/generators/project.ts
+++ b/create-digitaltwin/src/generators/project.ts
@@ -109,7 +109,7 @@ async function generatePackageJson(projectPath: string, answers: ProjectAnswers)
 
     const dependencies: PackageJsonDependencies = {
         'digitaltwin-core': `^${digitalTwinVersion}`,
-        'knex': '^3.0.0',
+        'kysely': '^0.28.0',
         'dotenv' : '^17.2.1'
     }
 
@@ -238,21 +238,14 @@ function generateIndexFile(answers: ProjectAnswers): string {
 
     const dbConfig = database === 'postgresql'
         ? `{
-    client: 'pg',
-    connection: {
-      host: env.DB_HOST,
-      port: env.DB_PORT || 5432,
-      user: env.DB_USER,
-      password: env.DB_PASSWORD,
-      database: env.DB_NAME
-    }
+    host: env.DB_HOST,
+    port: env.DB_PORT || 5432,
+    user: env.DB_USER,
+    password: env.DB_PASSWORD,
+    database: env.DB_NAME
   }`
         : `{
-    client: 'better-sqlite3',
-    connection: {
-      filename: env.DB_PATH || './data/${projectName}.db'
-    },
-    useNullAsDefault: true
+    filename: env.DB_PATH || './data/${projectName}.db'
   }`
 
     const exampleComponents = includeExamples
@@ -267,7 +260,7 @@ function generateIndexFile(answers: ProjectAnswers): string {
     const dbDisplay = database === 'postgresql' ? 'PostgreSQL' : 'SQLite'
 
     return `${dotenvImport}
-import { DigitalTwinEngine, KnexDatabaseAdapter, Env, setupGracefulShutdown } from 'digitaltwin-core'
+import { DigitalTwinEngine, KyselyDatabaseAdapter, Env, setupGracefulShutdown } from 'digitaltwin-core'
 import { ${storageClass} } from 'digitaltwin-core'
 ${exampleImports}
 
@@ -284,7 +277,7 @@ async function main(): Promise<void> {
   const dbConfig = ${dbConfig}
 
   // Initialize database adapter
-  const database = new KnexDatabaseAdapter(dbConfig, storage)
+  const database = await KyselyDatabaseAdapter.${database === 'postgresql' ? 'forPostgreSQL' : 'forSQLite'}(dbConfig, (url) => storage.retrieve(url))
 
   // Create Digital Twin Engine
   const engine = new DigitalTwinEngine({

--- a/digitaltwin-core/package.json
+++ b/digitaltwin-core/package.json
@@ -25,8 +25,8 @@
     "test": "node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
     "test:coverage": "c8 node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
     "test:coverage:html": "c8 --reporter=html node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix",
+    "lint": "eslint src tests --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint src tests --fix --no-error-on-unmatched-pattern",
     "format": "prettier --write \"src/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "check": "npm run lint && npm run format:check && npm run build",
@@ -54,7 +54,6 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.0.0",
     "@japa/assert": "^4.1.0",
     "@japa/runner": "^4.3.0",
     "@testcontainers/redis": "^11.3.1",
@@ -67,12 +66,9 @@
     "better-sqlite3": "^12.6.0",
     "jszip": "^3.10.1",
     "c8": "^10.1.3",
-    "eslint": "^9.0.0",
-    "globals": "^15.0.0",
     "prettier": "^3.0.0",
     "testcontainers": "^11.3.1",
-    "ts-node-maintained": "^10.9.5",
-    "typescript-eslint": "^8.0.0"
+    "ts-node-maintained": "^10.9.5"
   },
   "peerDependencies": {
     "better-sqlite3": "^12.2.0",

--- a/digitaltwin-core/src/database/adapters/knex_database_adapter.ts
+++ b/digitaltwin-core/src/database/adapters/knex_database_adapter.ts
@@ -1,3 +1,5 @@
 // Re-exported from @digitaltwin/database for backward compatibility
 export { KnexDatabaseAdapter } from '@digitaltwin/database'
 export type { PostgreSQLConfig, SQLiteConfig } from '@digitaltwin/database'
+export { KyselyDatabaseAdapter } from '@digitaltwin/database'
+export type { KyselyPostgreSQLConfig, KyselySQLiteConfig } from '@digitaltwin/database'

--- a/digitaltwin-core/src/index.ts
+++ b/digitaltwin-core/src/index.ts
@@ -41,7 +41,7 @@ export { StorageServiceFactory } from './storage/storage_factory.js'
 
 // Database Services
 export { DatabaseAdapter } from './database/database_adapter.js'
-export { KnexDatabaseAdapter, PostgreSQLConfig, SQLiteConfig } from './database/adapters/knex_database_adapter.js'
+export { KnexDatabaseAdapter, PostgreSQLConfig, SQLiteConfig, KyselyDatabaseAdapter, KyselyPostgreSQLConfig, KyselySQLiteConfig } from './database/adapters/knex_database_adapter.js'
 
 // Types and Interfaces
 export * from './components/types.js'

--- a/digitaltwin-core/tests/components/tileset_manager.spec.ts
+++ b/digitaltwin-core/tests/components/tileset_manager.spec.ts
@@ -648,12 +648,8 @@ test.group('TilesetManager.handleDelete with auth', group => {
         const storage = new LocalStorageService('.test-delete-forbidden')
         manager.setDependencies(db, storage)
 
-        // Create owner user
-        await db.getKnex()('users').insert({ keycloak_id: 'owner-1' })
-        const owner = await db.getKnex()('users').where('keycloak_id', 'owner-1').first()
-
-        // Create other user
-        await db.getKnex()('users').insert({ keycloak_id: 'other-user' })
+        const owner = await db.getUserRepository().findOrCreateUser({ id: 'owner-1', roles: ['user'] })
+        await db.getUserRepository().findOrCreateUser({ id: 'other-user', roles: ['user'] })
 
         const record = await db.save({
             name: 'test-tilesets',
@@ -681,8 +677,7 @@ test.group('TilesetManager.handleDelete with auth', group => {
         const storage = new LocalStorageService('.test-delete-admin')
         manager.setDependencies(db, storage)
 
-        await db.getKnex()('users').insert({ keycloak_id: 'owner-1' })
-        const owner = await db.getKnex()('users').where('keycloak_id', 'owner-1').first()
+        const owner = await db.getUserRepository().findOrCreateUser({ id: 'owner-1', roles: ['user'] })
 
         const record = await db.save({
             name: 'test-tilesets',
@@ -799,9 +794,7 @@ test.group('TilesetManager.retrieve filtering', group => {
         const storage = new LocalStorageService('.test-retrieve-owner')
         manager.setDependencies(db, storage)
 
-        // Create owner user
-        await db.getKnex()('users').insert({ keycloak_id: 'owner-user' })
-        const user = await db.getKnex()('users').where('keycloak_id', 'owner-user').first()
+        const user = await db.getUserRepository().findOrCreateUser({ id: 'owner-user', roles: ['user'] })
 
         await db.save({
             name: 'test-tilesets',

--- a/digitaltwin-core/tests/engine/initializer.spec.ts
+++ b/digitaltwin-core/tests/engine/initializer.spec.ts
@@ -174,7 +174,7 @@ test.group('initializeComponents', () => {
     // Mock all tables to exist
     database.doesTableExists = async (tableName: string) => true
     
-    let initializationOrder: string[] = []
+    const initializationOrder: string[] = []
     
     collector.setDependencies = (db, st) => {
       initializationOrder.push('collector')

--- a/digitaltwin-core/tests/http_integration.spec.ts
+++ b/digitaltwin-core/tests/http_integration.spec.ts
@@ -164,8 +164,6 @@ test('HTTP Integration - Real endpoints via GET requests', async ({ assert }) =>
       
       assert.equal(notFoundResponse.status, 404, 'Non-existent endpoint should return 404')
       
-    } catch (error) {
-      throw error
     } finally {
       // Graceful stop with proper timeout
       try {

--- a/digitaltwin-core/tests/mocks/mock_database_adapter.ts
+++ b/digitaltwin-core/tests/mocks/mock_database_adapter.ts
@@ -323,10 +323,6 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
         return knex
     }
 
-    getKnex(): any {
-        return this.mockKnex
-    }
-
     // Reset mock state (useful between tests)
     resetMockState(): void {
         this.users.clear()
@@ -638,6 +634,8 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
         // Mock implementation - tables exist automatically
     }
 
+    async ensureColumns(_tableName: string, _columns: Record<string, string>): Promise<void> {}
+
     async findByConditions(tableName: string, conditions: Record<string, any>): Promise<DataRecord[]> {
         // Filter records by table name and conditions
         return Array.from(this.records.values())
@@ -725,8 +723,7 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
         const users = this.users
         const roles = this.roles
         const userRoles = this.userRoles
-        let nextUserId = 100
-        let nextRoleId = 100
+        const self = this
 
         return {
             async initializeTables(): Promise<void> {
@@ -746,7 +743,7 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
                     }
                 }
                 // Create new user
-                const id = nextUserId++
+                const id = self.userIdCounter++
                 const now = new Date()
                 users.set(id, { id, keycloak_id: authUser.id, created_at: now, updated_at: now })
                 return { id, keycloak_id: authUser.id, roles: authUser.roles, created_at: now, updated_at: now }

--- a/digitaltwin-core/tests/mocks/mock_database_adapter.ts
+++ b/digitaltwin-core/tests/mocks/mock_database_adapter.ts
@@ -88,11 +88,11 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
 
         const createQueryBuilder = (tableName: string) => {
             let whereConditions: Record<string, any> = {}
-            let whereInConditions: Array<{ column: string; values: any[] }> = []
+            const whereInConditions: Array<{ column: string; values: any[] }> = []
             let insertData: any = null
             let updateData: any = null
             let selectedColumns: string[] = ['*']
-            let joins: Array<{ type: string; table: string; col1: string; col2: string }> = []
+            const joins: Array<{ type: string; table: string; col1: string; col2: string }> = []
 
             const queryBuilder: any = {
                 select: (...cols: string[]) => {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import globals from 'globals'
 export default tseslint.config(
     js.configs.recommended,
     ...tseslint.configs.recommended,
-    
+
     {
         languageOptions: {
             globals: {
@@ -14,24 +14,19 @@ export default tseslint.config(
             }
         }
     },
-    
+
     // TypeScript files configuration
     {
-        files: ['src/**/*.ts'],
-        languageOptions: {
-            parserOptions: {
-                project: './tsconfig.json'
-            }
-        },
+        files: ['**/src/**/*.ts'],
         rules: {
             // Code Quality - Permissive for existing codebase
-            '@typescript-eslint/no-unused-vars': ['warn', { 
+            '@typescript-eslint/no-unused-vars': ['warn', {
                 argsIgnorePattern: '^_',
-                varsIgnorePattern: '^_' 
+                varsIgnorePattern: '^_'
             }],
             '@typescript-eslint/no-explicit-any': 'off', // Allow any for flexibility
             '@typescript-eslint/explicit-function-return-type': 'off', // Too restrictive
-            
+
             // Disable problematic rules for your codebase
             '@typescript-eslint/naming-convention': 'off', // Too restrictive
             '@typescript-eslint/prefer-nullish-coalescing': 'off',
@@ -42,7 +37,7 @@ export default tseslint.config(
             '@typescript-eslint/require-await': 'off',
             '@typescript-eslint/no-unnecessary-type-assertion': 'off',
             '@typescript-eslint/prefer-readonly': 'off',
-            
+
             // Style consistency - Let Prettier handle formatting
             'indent': 'off',
             'quotes': 'off',
@@ -56,26 +51,26 @@ export default tseslint.config(
             'no-trailing-spaces': 'off',
             'eol-last': 'off',
             'no-case-declarations': 'off',
-            
+
             // Import/Export - Keep this useful rule
             '@typescript-eslint/consistent-type-imports': ['warn', {
                 prefer: 'type-imports',
                 disallowTypeAnnotations: false
             }],
-            
+
             // Basic error prevention
             '@typescript-eslint/no-non-null-assertion': 'warn',
             '@typescript-eslint/ban-ts-comment': ['warn', {
                 'ts-expect-error': 'allow-with-description',
                 'ts-ignore': 'allow-with-description'
             }],
-            
+
             // Disable conflicting base rules
             'no-unused-vars': 'off',
             'no-undef': 'off'
         }
     },
-    
+
     // Test files - Even more permissive
     {
         files: ['**/*.spec.ts', '**/*.test.ts', '**/tests/**/*'],
@@ -83,10 +78,12 @@ export default tseslint.config(
             '@typescript-eslint/no-explicit-any': 'off',
             '@typescript-eslint/no-non-null-assertion': 'off',
             '@typescript-eslint/no-unused-vars': 'off',
-            '@typescript-eslint/consistent-type-imports': 'off'
+            '@typescript-eslint/consistent-type-imports': 'off',
+            '@typescript-eslint/no-this-alias': 'off',
+            '@typescript-eslint/no-unsafe-function-type': 'off'
         }
     },
-    
+
     // Example files - Very permissive
     {
         files: ['**/examples/**/*'],
@@ -96,7 +93,7 @@ export default tseslint.config(
             '@typescript-eslint/consistent-type-imports': 'off'
         }
     },
-    
+
     // Ignore patterns
     {
         ignores: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "digitaltwin",
   "private": true,
+  "type": "module",
   "description": "Digital Twin Framework Monorepo",
   "scripts": {
     "build": "pnpm -r run build",
@@ -11,8 +12,8 @@
     "clean": "pnpm -r run clean",
     "test": "pnpm --filter @digitaltwin/shared run test && pnpm --filter @digitaltwin/database run test && pnpm --filter @digitaltwin/storage run test && pnpm --filter @digitaltwin/auth run test && pnpm --filter @digitaltwin/assets run test && pnpm --filter @digitaltwin/ngsi-ld run test && pnpm --filter @digitaltwin/engine run test && pnpm --filter digitaltwin-core run test",
     "test:shared": "pnpm --filter @digitaltwin/shared run test",
-    "lint": "pnpm --filter digitaltwin-core run lint",
-    "lint:fix": "pnpm --filter digitaltwin-core run lint:fix",
+    "lint": "pnpm -r run lint",
+    "lint:fix": "pnpm -r run lint:fix",
     "format": "pnpm --filter digitaltwin-core run format",
     "format:check": "pnpm --filter digitaltwin-core run format:check",
     "check": "pnpm --filter digitaltwin-core run check"
@@ -21,11 +22,15 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
-    "@types/node": "^24.1.0",
+    "@eslint/js": "^9.39.2",
     "@types/fs-extra": "^11.0.4",
+    "@types/node": "^24.1.0",
+    "eslint": "^9.39.2",
+    "globals": "^15.15.0",
     "rimraf": "^6.0.1",
     "tsx": "^4.20.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "typescript-eslint": "^8.53.0"
   },
   "pnpm": {
     "overrides": {

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -23,8 +23,8 @@
     "dev": "tsc --watch",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "test": "node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix"
+    "lint": "eslint src tests --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint src tests --fix --no-error-on-unmatched-pattern"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/assets/tests/mocks/mock_database_adapter.ts
+++ b/packages/assets/tests/mocks/mock_database_adapter.ts
@@ -31,7 +31,6 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
     private records: Map<string, DataRecord> = new Map()
     private dataResolver: DataResolver
     private shouldThrow: Required<NonNullable<MockDatabaseOptions['shouldThrow']>>
-    private mockKnex: ReturnType<typeof this.createMockKnex>
     private users: Map<number, { id: number; keycloak_id: string; created_at: Date; updated_at: Date }> = new Map()
     private roles: Map<number, { id: number; name: string; created_at: Date }> = new Map()
     private userRoles: Array<{ user_id: number; role_id: number; created_at: Date }> = []
@@ -71,208 +70,6 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
             countByDateRange: options.shouldThrow?.countByDateRange ?? false,
         }
 
-        this.mockKnex = this.createMockKnex()
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private createMockKnex(): any {
-        const self = this
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const createQueryBuilder = (tableName: string): any => {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            let whereConditions: Record<string, any> = {}
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            let whereInConditions: Array<{ column: string; values: any[] }> = []
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            let insertData: any = null
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            let updateData: any = null
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const queryBuilder: any = {
-                select: (..._cols: string[]) => queryBuilder,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                where: (conditions: Record<string, any> | string, value?: any) => {
-                    if (typeof conditions === 'string') {
-                        whereConditions[conditions] = value
-                    } else {
-                        whereConditions = { ...whereConditions, ...conditions }
-                    }
-                    return queryBuilder
-                },
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                whereIn: (column: string, values: any[]) => {
-                    whereInConditions.push({ column, values })
-                    return queryBuilder
-                },
-                leftJoin: (_table: string, _col1: string, _col2: string) => queryBuilder,
-                join: (_table: string, _col1: string, _col2: string) => queryBuilder,
-                first: async () => {
-                    if (tableName === 'users') {
-                        for (const user of self.users.values()) {
-                            let match = true
-                            for (const [key, val] of Object.entries(whereConditions)) {
-                                if ((user as Record<string, unknown>)[key] !== val) match = false
-                            }
-                            if (match) return user
-                        }
-                        return undefined
-                    }
-                    if (tableName === 'roles') {
-                        for (const role of self.roles.values()) {
-                            let match = true
-                            for (const [key, val] of Object.entries(whereConditions)) {
-                                if ((role as Record<string, unknown>)[key] !== val) match = false
-                            }
-                            if (match) return role
-                        }
-                        return undefined
-                    }
-                    return undefined
-                },
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                insert: (data: any) => {
-                    insertData = data
-                    return {
-                        ...queryBuilder,
-                        onConflict: () => ({
-                            ignore: () => queryBuilder,
-                            merge: () => queryBuilder
-                        })
-                    }
-                },
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                update: (data: any) => {
-                    updateData = data
-                    return queryBuilder
-                },
-                del: async () => {
-                    if (tableName === 'user_roles') {
-                        self.userRoles = self.userRoles.filter(ur => {
-                            for (const [key, val] of Object.entries(whereConditions)) {
-                                if ((ur as Record<string, unknown>)[key] !== val) return true
-                            }
-                            return false
-                        })
-                    }
-                    return 1
-                },
-                delete: async function() {
-                    return queryBuilder.del()
-                },
-                returning: () => queryBuilder,
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                then: async (resolve: (value: any) => void, reject?: (err: Error) => void) => {
-                    try {
-                        if (insertData) {
-                            if (tableName === 'users') {
-                                const id = self.userIdCounter++
-                                const user = { id, ...insertData, created_at: new Date(), updated_at: new Date() }
-                                self.users.set(id, user)
-                                resolve([{ id }])
-                            } else if (tableName === 'roles') {
-                                const id = self.roleIdCounter++
-                                const role = { id, ...insertData, created_at: new Date() }
-                                self.roles.set(id, role)
-                                resolve([{ id }])
-                            } else if (tableName === 'user_roles') {
-                                self.userRoles.push({ ...insertData, created_at: new Date() })
-                                resolve([])
-                            } else {
-                                resolve([])
-                            }
-                        } else if (updateData) {
-                            if (tableName === 'users') {
-                                for (const user of self.users.values()) {
-                                    let match = true
-                                    for (const [key, val] of Object.entries(whereConditions)) {
-                                        if ((user as Record<string, unknown>)[key] !== val) match = false
-                                    }
-                                    if (match) {
-                                        Object.assign(user, updateData)
-                                    }
-                                }
-                            }
-                            resolve(1)
-                        } else {
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            const matchesWhereIn = (item: Record<string, any>): boolean => {
-                                for (const { column, values } of whereInConditions) {
-                                    if (!values.includes(item[column])) return false
-                                }
-                                return true
-                            }
-
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                            const matchesWhere = (item: Record<string, any>, conditions: Record<string, any>): boolean => {
-                                for (const [key, val] of Object.entries(conditions)) {
-                                    const actualKey = key.includes('.') ? key.split('.').pop()! : key
-                                    if (item[actualKey] !== val) return false
-                                }
-                                return true
-                            }
-
-                            if (tableName === 'users') {
-                                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                const results: any[] = []
-                                for (const user of self.users.values()) {
-                                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                    if (matchesWhere(user as any, whereConditions) && matchesWhereIn(user as any)) {
-                                        results.push(user)
-                                    }
-                                }
-                                resolve(results)
-                            } else if (tableName === 'roles') {
-                                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                const results: any[] = []
-                                for (const role of self.roles.values()) {
-                                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                    if (matchesWhere(role as any, whereConditions) && matchesWhereIn(role as any)) {
-                                        results.push(role)
-                                    }
-                                }
-                                resolve(results)
-                            } else if (tableName === 'user_roles') {
-                                const results = self.userRoles.filter(ur => {
-                                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                                    return matchesWhere(ur as any, whereConditions) && matchesWhereIn(ur as any)
-                                })
-                                resolve(results)
-                            } else {
-                                resolve([])
-                            }
-                        }
-                    } catch (e) {
-                        if (reject) reject(e as Error)
-                        else throw e
-                    }
-                }
-            }
-            return queryBuilder
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const knex: any = (tableName: string) => createQueryBuilder(tableName)
-
-        knex.schema = {
-            hasTable: async (tableName: string) => {
-                return tableName === 'users' || tableName === 'roles' || tableName === 'user_roles'
-            },
-            createTable: async () => true
-        }
-
-        knex.raw = async () => ({ rows: [] })
-        knex.fn = { now: () => new Date() }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        knex.transaction = async (callback: (trx: any) => Promise<any>) => callback(knex)
-
-        return knex
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getKnex(): any {
-        return this.mockKnex
     }
 
     resetMockState(): void {
@@ -439,6 +236,8 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
 
     async createTableWithColumns(_name: string, _columns: Record<string, string>): Promise<void> {}
 
+    async ensureColumns(_tableName: string, _columns: Record<string, string>): Promise<void> {}
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async findByConditions(tableName: string, conditions: Record<string, any>): Promise<DataRecord[]> {
         return Array.from(this.records.values())
@@ -510,7 +309,7 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
 
     getUserRepository(): UserRepository {
         const users = this.users
-        let nextUserId = 100
+        const self = this
 
         return {
             async initializeTables(): Promise<void> {},
@@ -523,7 +322,7 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
                         }
                     }
                 }
-                const id = nextUserId++
+                const id = self.userIdCounter++
                 const now = new Date()
                 users.set(id, { id, keycloak_id: authUser.id, created_at: now, updated_at: now })
                 return { id, keycloak_id: authUser.id, roles: authUser.roles, created_at: now, updated_at: now }

--- a/packages/assets/tests/tileset_manager.spec.ts
+++ b/packages/assets/tests/tileset_manager.spec.ts
@@ -477,9 +477,8 @@ test.group('TilesetManager — delete with auth', (group) => {
         const storage = new LocalStorageService('.test-delete-forbidden')
         manager.setDependencies(db, storage)
 
-        await db.getKnex()('users').insert({ keycloak_id: 'owner-1' })
-        const owner = await db.getKnex()('users').where('keycloak_id', 'owner-1').first()
-        await db.getKnex()('users').insert({ keycloak_id: 'other-user' })
+        const owner = await db.getUserRepository().findOrCreateUser({ id: 'owner-1', roles: ['user'] })
+        await db.getUserRepository().findOrCreateUser({ id: 'other-user', roles: ['user'] })
 
         const record = await db.save({
             name: 'test-tilesets', type: 'application/json',
@@ -503,8 +502,7 @@ test.group('TilesetManager — delete with auth', (group) => {
         const storage = new LocalStorageService('.test-delete-admin')
         manager.setDependencies(db, storage)
 
-        await db.getKnex()('users').insert({ keycloak_id: 'owner-1' })
-        const owner = await db.getKnex()('users').where('keycloak_id', 'owner-1').first()
+        const owner = await db.getUserRepository().findOrCreateUser({ id: 'owner-1', roles: ['user'] })
 
         const record = await db.save({
             name: 'test-tilesets', type: 'application/json',
@@ -592,8 +590,7 @@ test.group('TilesetManager — retrieve with visibility filtering', (group) => {
         const storage = new LocalStorageService('.test-retrieve-owner')
         manager.setDependencies(db, storage)
 
-        await db.getKnex()('users').insert({ keycloak_id: 'owner-user' })
-        const user = await db.getKnex()('users').where('keycloak_id', 'owner-user').first()
+        const user = await db.getUserRepository().findOrCreateUser({ id: 'owner-user', roles: ['user'] })
 
         await db.save({
             name: 'test-tilesets', type: 'application/json',

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -23,8 +23,8 @@
     "dev": "tsc --watch",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "test": "node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix"
+    "lint": "eslint src tests --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint src tests --fix --no-error-on-unmatched-pattern"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,8 +23,8 @@
     "dev": "tsc --watch",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "test": "node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix"
+    "lint": "eslint src tests --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint src tests --fix --no-error-on-unmatched-pattern"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/database/bin/test.ts
+++ b/packages/database/bin/test.ts
@@ -14,7 +14,7 @@ configure({
         activated: ['spec'],
         list: [reporters.spec()],
     },
-    timeout: 10000,
+    timeout: 30000,
     forceExit: true,
     filters: {
         tests: process.env.TEST_NAME ? [process.env.TEST_NAME] : [],

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -23,8 +23,8 @@
     "dev": "tsc --watch",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "test": "node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix"
+    "lint": "eslint src tests --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint src tests --fix --no-error-on-unmatched-pattern"
   },
   "engines": {
     "node": ">=20.0.0"
@@ -47,8 +47,11 @@
   "devDependencies": {
     "@japa/assert": "^4.1.0",
     "@japa/runner": "^4.3.0",
+    "@testcontainers/postgresql": "^11.12.0",
+    "@types/pg": "^8.18.0",
     "better-sqlite3": "^12.6.0",
     "kysely": "^0.28.11",
+    "pg": "^8.20.0",
     "ts-node-maintained": "^10.9.5"
   },
   "repository": {

--- a/packages/database/src/adapters/kysely_database_adapter.ts
+++ b/packages/database/src/adapters/kysely_database_adapter.ts
@@ -372,7 +372,7 @@ export class KyselyDatabaseAdapter extends DatabaseAdapter {
 
         for (const col of columnsToAdd) {
             if (!(await this.#columnExists(name, col.name))) {
-                let alter = this.#db.schema.alterTable(name).addColumn(col.name, col.type as any, (c: any) => {
+                const alter = this.#db.schema.alterTable(name).addColumn(col.name, col.type as any, (c: any) => {
                     if (col.defaultVal !== undefined) c = c.defaultTo(col.defaultVal)
                     if (col.notNull) c = c.notNull()
                     return c

--- a/packages/database/src/adapters/kysely_database_adapter.ts
+++ b/packages/database/src/adapters/kysely_database_adapter.ts
@@ -764,7 +764,7 @@ export class KyselyDatabaseAdapter extends DatabaseAdapter {
     }
 
     getUserRepository(): UserRepository {
-        return new KyselyUserRepository(this.#db)
+        return new KyselyUserRepository(this.#db, this.#dialect)
     }
 
     /** Expose the Kysely instance for advanced operations or testing */

--- a/packages/database/src/kysely_user_repository.ts
+++ b/packages/database/src/kysely_user_repository.ts
@@ -11,20 +11,26 @@ import type { AuthenticatedUser, UserRecord, UserRepository } from '@digitaltwin
  */
 export class KyselyUserRepository implements UserRepository {
     readonly #db: Kysely<any>
+    readonly #dialect: 'postgres' | 'sqlite'
 
-    constructor(db: Kysely<any>) {
+    constructor(db: Kysely<any>, dialect: 'postgres' | 'sqlite' = 'sqlite') {
         this.#db = db
+        this.#dialect = dialect
     }
 
     async initializeTables(): Promise<void> {
         const tables = await this.#db.introspection.getTables()
         const tableNames = new Set(tables.map(t => t.name))
+        const idCol = this.#dialect === 'postgres' ? 'serial' : 'integer'
+        const withAutoInc = this.#dialect === 'postgres'
+            ? (col: any) => col.primaryKey()
+            : (col: any) => col.primaryKey().autoIncrement()
 
         // 1. Create roles table
         if (!tableNames.has('roles')) {
             await this.#db.schema
                 .createTable('roles')
-                .addColumn('id', 'integer', col => col.primaryKey().autoIncrement())
+                .addColumn('id', idCol, withAutoInc)
                 .addColumn('name', 'varchar(100)', col => col.notNull().unique())
                 .addColumn('created_at', 'timestamp', col => col.defaultTo(sql`CURRENT_TIMESTAMP`))
                 .execute()
@@ -36,7 +42,7 @@ export class KyselyUserRepository implements UserRepository {
         if (!tableNames.has('users')) {
             await this.#db.schema
                 .createTable('users')
-                .addColumn('id', 'integer', col => col.primaryKey().autoIncrement())
+                .addColumn('id', idCol, withAutoInc)
                 .addColumn('keycloak_id', 'varchar(255)', col => col.notNull().unique())
                 .addColumn('created_at', 'timestamp', col => col.defaultTo(sql`CURRENT_TIMESTAMP`))
                 .addColumn('updated_at', 'timestamp', col => col.defaultTo(sql`CURRENT_TIMESTAMP`))

--- a/packages/database/tests/helpers/factories.ts
+++ b/packages/database/tests/helpers/factories.ts
@@ -1,0 +1,58 @@
+import Database from 'better-sqlite3'
+import { Kysely, SqliteDialect, PostgresDialect } from 'kysely'
+import { KyselyDatabaseAdapter } from '../../src/adapters/kysely_database_adapter.js'
+import type { DataResolver } from '@digitaltwin/shared'
+
+const dataResolver: DataResolver = async () => Buffer.alloc(0)
+
+export type AdapterFactory = () => Promise<{ db: KyselyDatabaseAdapter; cleanup: () => Promise<void> }>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type KyselyFactory = () => Promise<{ db: Kysely<any>; cleanup: () => Promise<void> }>
+
+function pgConfig() {
+    return {
+        host: process.env.TEST_PG_HOST!,
+        port: Number(process.env.TEST_PG_PORT),
+        user: process.env.TEST_PG_USER!,
+        password: process.env.TEST_PG_PASSWORD!,
+        database: process.env.TEST_PG_DATABASE!,
+    }
+}
+
+export const sqliteAdapterFactory: AdapterFactory = async () => {
+    const sqliteDb = new Database(':memory:')
+    const db = KyselyDatabaseAdapter.fromSQLiteDatabase(sqliteDb, dataResolver, { enableForeignKeys: false })
+    sqliteDb.exec(`
+        CREATE TABLE users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            keycloak_id VARCHAR(255) NOT NULL UNIQUE,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    `)
+    return { db, cleanup: () => db.close() }
+}
+
+export const postgresAdapterFactory: AdapterFactory = async () => {
+    const db = await KyselyDatabaseAdapter.forPostgreSQL(pgConfig(), dataResolver)
+    await db.getUserRepository().initializeTables()
+    return { db, cleanup: () => db.close() }
+}
+
+export const sqliteKyselyFactory: KyselyFactory = async () => {
+    const sqliteDb = new Database(':memory:')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const db = new Kysely<any>({ dialect: new SqliteDialect({ database: sqliteDb }) })
+    return { db, cleanup: () => db.destroy() }
+}
+
+export const postgresKyselyFactory: KyselyFactory = async () => {
+    const pg = await import('pg')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const Pool = (pg.default as any)?.Pool ?? pg.Pool
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pool = new Pool(pgConfig())
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const db = new Kysely<any>({ dialect: new PostgresDialect({ pool: pool as any }) })
+    return { db, cleanup: () => db.destroy() }
+}

--- a/packages/database/tests/helpers/factories.ts
+++ b/packages/database/tests/helpers/factories.ts
@@ -7,7 +7,7 @@ const dataResolver: DataResolver = async () => Buffer.alloc(0)
 
 export type AdapterFactory = () => Promise<{ db: KyselyDatabaseAdapter; cleanup: () => Promise<void> }>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type KyselyFactory = () => Promise<{ db: Kysely<any>; cleanup: () => Promise<void> }>
+export type KyselyFactory = () => Promise<{ db: Kysely<any>; dialect: 'postgres' | 'sqlite'; cleanup: () => Promise<void> }>
 
 function pgConfig() {
     return {
@@ -43,7 +43,7 @@ export const sqliteKyselyFactory: KyselyFactory = async () => {
     const sqliteDb = new Database(':memory:')
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db = new Kysely<any>({ dialect: new SqliteDialect({ database: sqliteDb }) })
-    return { db, cleanup: () => db.destroy() }
+    return { db, dialect: 'sqlite', cleanup: () => db.destroy() }
 }
 
 export const postgresKyselyFactory: KyselyFactory = async () => {
@@ -54,5 +54,5 @@ export const postgresKyselyFactory: KyselyFactory = async () => {
     const pool = new Pool(pgConfig())
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db = new Kysely<any>({ dialect: new PostgresDialect({ pool: pool as any }) })
-    return { db, cleanup: () => db.destroy() }
+    return { db, dialect: 'postgres', cleanup: () => db.destroy() }
 }

--- a/packages/database/tests/kysely_database_adapter.spec.ts
+++ b/packages/database/tests/kysely_database_adapter.spec.ts
@@ -1,487 +1,403 @@
 import { test } from '@japa/runner'
-import Database from 'better-sqlite3'
+import { sql } from 'kysely'
 import { KyselyDatabaseAdapter } from '../src/adapters/kysely_database_adapter.js'
-import type { DataResolver } from '@digitaltwin/shared'
+import { sqliteAdapterFactory, postgresAdapterFactory } from './helpers/factories.js'
+import type { AdapterFactory } from './helpers/factories.js'
 
-function createTestDb(): { db: KyselyDatabaseAdapter; cleanup: () => Promise<void> } {
-    const sqliteDb = new Database(':memory:')
-    const dataResolver: DataResolver = async () => Buffer.alloc(0)
+const pgAvailable = !!process.env.TEST_PG_HOST
 
-    const db = KyselyDatabaseAdapter.fromSQLiteDatabase(
-        sqliteDb, dataResolver, { enableForeignKeys: false }
-    )
+function registerAdapterTests(label: string, factory: AdapterFactory) {
+    test.group(`KyselyDatabaseAdapter [${label}] - Basic Operations`, group => {
+        let db: KyselyDatabaseAdapter
+        let cleanup: () => Promise<void>
 
-    // Create users table (needed for FK in createTable)
-    sqliteDb.exec(`
-        CREATE TABLE users (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            keycloak_id VARCHAR(255) NOT NULL UNIQUE,
-            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-        )
-    `)
+        group.setup(async () => {
+            const result = await factory()
+            db = result.db
+            cleanup = result.cleanup
+        })
+        group.teardown(async () => { await cleanup() })
 
-    const cleanup = async () => {
-        await db.close()
+        test('createTable creates table with expected columns', async ({ assert }) => {
+            await db.createTable(`${label}_basic`)
+            assert.isTrue(await db.doesTableExists(`${label}_basic`))
+        })
+
+        test('save inserts a record and returns it with ID', async ({ assert }) => {
+            await db.createTable(`${label}_save`)
+            const record = await db.save({ name: `${label}_save`, type: 'application/json', url: '/test/file.json', date: new Date() })
+            assert.isDefined(record.id)
+            assert.equal(record.name, `${label}_save`)
+            assert.equal(record.contentType, 'application/json')
+        })
+
+        test('getById retrieves record by ID', async ({ assert }) => {
+            await db.createTable(`${label}_getbyid`)
+            const saved = await db.save({ name: `${label}_getbyid`, type: 'text/plain', url: '/test.txt', date: new Date() })
+            const fetched = await db.getById(String(saved.id), `${label}_getbyid`)
+            assert.isDefined(fetched)
+            assert.equal(fetched!.id, saved.id)
+        })
+
+        test('getById returns undefined for non-existent ID', async ({ assert }) => {
+            await db.createTable(`${label}_getbyid_none`)
+            assert.isUndefined(await db.getById('99999', `${label}_getbyid_none`))
+        })
+
+        test('delete removes a record', async ({ assert }) => {
+            await db.createTable(`${label}_delete`)
+            const saved = await db.save({ name: `${label}_delete`, type: 'text/plain', url: '/test.txt', date: new Date() })
+            await db.delete(String(saved.id), `${label}_delete`)
+            assert.isUndefined(await db.getById(String(saved.id), `${label}_delete`))
+        })
+
+        test('getLatestByName returns most recent record', async ({ assert }) => {
+            await db.createTable(`${label}_latest`)
+            await db.save({ name: `${label}_latest`, type: 'text/plain', url: '/old.txt', date: new Date('2024-01-01') })
+            await db.save({ name: `${label}_latest`, type: 'text/plain', url: '/new.txt', date: new Date('2024-06-01') })
+            const latest = await db.getLatestByName(`${label}_latest`)
+            assert.equal(latest!.url, '/new.txt')
+        })
+
+        test('doesTableExists returns false for non-existent table', async ({ assert }) => {
+            assert.isFalse(await db.doesTableExists('non_existent_table_xyz'))
+        })
+    })
+
+    test.group(`KyselyDatabaseAdapter [${label}] - Extended Queries`, group => {
+        let db: KyselyDatabaseAdapter
+        let cleanup: () => Promise<void>
+
+        group.setup(async () => {
+            const result = await factory()
+            db = result.db
+            cleanup = result.cleanup
+            await db.createTable(`${label}_queries`)
+            const dates = [
+                new Date('2024-01-15'), new Date('2024-02-15'), new Date('2024-03-15'),
+                new Date('2024-04-15'), new Date('2024-05-15'),
+            ]
+            for (let i = 0; i < dates.length; i++) {
+                await db.save({ name: `${label}_queries`, type: 'text/plain', url: `/file${i + 1}.txt`, date: dates[i] })
+            }
+        })
+        group.teardown(async () => { await cleanup() })
+
+        test('getFirstByName returns oldest record', async ({ assert }) => {
+            const first = await db.getFirstByName(`${label}_queries`)
+            assert.equal(first!.url, '/file1.txt')
+        })
+
+        test('getByDateRange returns records in range', async ({ assert }) => {
+            const records = await db.getByDateRange(`${label}_queries`, new Date('2024-02-01'), new Date('2024-04-01'))
+            assert.lengthOf(records, 2)
+            assert.equal(records[0].url, '/file2.txt')
+        })
+
+        test('getByDateRange with limit restricts results', async ({ assert }) => {
+            const records = await db.getByDateRange(`${label}_queries`, new Date('2024-01-01'), undefined, 2)
+            assert.lengthOf(records, 2)
+        })
+
+        test('getByDateRange with desc order returns newest first', async ({ assert }) => {
+            const records = await db.getByDateRange(`${label}_queries`, new Date('2024-01-01'), new Date('2024-06-01'), undefined, 'desc')
+            assert.lengthOf(records, 5)
+            assert.equal(records[0].url, '/file5.txt')
+        })
+
+        test('getAfterDate returns records after date', async ({ assert }) => {
+            const records = await db.getAfterDate(`${label}_queries`, new Date('2024-04-01'))
+            assert.lengthOf(records, 2)
+            assert.equal(records[0].url, '/file4.txt')
+        })
+
+        test('getLatestBefore returns most recent before date', async ({ assert }) => {
+            const record = await db.getLatestBefore(`${label}_queries`, new Date('2024-03-20'))
+            assert.equal(record!.url, '/file3.txt')
+        })
+
+        test('getLatestRecordsBefore returns multiple records', async ({ assert }) => {
+            const records = await db.getLatestRecordsBefore(`${label}_queries`, new Date('2024-05-01'), 2)
+            assert.lengthOf(records, 2)
+            assert.equal(records[0].url, '/file4.txt')
+        })
+
+        test('hasRecordsAfterDate returns true when records exist', async ({ assert }) => {
+            assert.isTrue(await db.hasRecordsAfterDate(`${label}_queries`, new Date('2024-04-01')))
+        })
+
+        test('hasRecordsAfterDate returns false when no records', async ({ assert }) => {
+            assert.isFalse(await db.hasRecordsAfterDate(`${label}_queries`, new Date('2025-01-01')))
+        })
+
+        test('countByDateRange counts records correctly', async ({ assert }) => {
+            assert.equal(await db.countByDateRange(`${label}_queries`, new Date('2024-02-01'), new Date('2024-05-01')), 3)
+        })
+    })
+
+    test.group(`KyselyDatabaseAdapter [${label}] - Batch Operations`, group => {
+        let db: KyselyDatabaseAdapter
+        let cleanup: () => Promise<void>
+
+        group.setup(async () => {
+            const result = await factory()
+            db = result.db
+            cleanup = result.cleanup
+        })
+        group.teardown(async () => { await cleanup() })
+
+        test('saveBatch inserts multiple records', async ({ assert }) => {
+            await db.createTable(`${label}_batch_save`)
+            const records = await db.saveBatch([
+                { name: `${label}_batch_save`, type: 'text/plain', url: '/b1.txt', date: new Date() },
+                { name: `${label}_batch_save`, type: 'text/plain', url: '/b2.txt', date: new Date() },
+                { name: `${label}_batch_save`, type: 'text/plain', url: '/b3.txt', date: new Date() },
+            ])
+            assert.lengthOf(records, 3)
+        })
+
+        test('saveBatch returns empty array for empty input', async ({ assert }) => {
+            assert.lengthOf(await db.saveBatch([]), 0)
+        })
+
+        test('deleteBatch removes multiple records', async ({ assert }) => {
+            await db.createTable(`${label}_batch_del`)
+            const s1 = await db.save({ name: `${label}_batch_del`, type: 'text/plain', url: '/d1.txt', date: new Date() })
+            const s2 = await db.save({ name: `${label}_batch_del`, type: 'text/plain', url: '/d2.txt', date: new Date() })
+            await db.deleteBatch([{ id: String(s1.id), name: `${label}_batch_del` }, { id: String(s2.id), name: `${label}_batch_del` }])
+            assert.equal(await db.countByDateRange(`${label}_batch_del`, new Date('2020-01-01')), 0)
+        })
+
+        test('getByIdsBatch retrieves multiple records', async ({ assert }) => {
+            await db.createTable(`${label}_batch_get`)
+            const s1 = await db.save({ name: `${label}_batch_get`, type: 'text/plain', url: '/g1.txt', date: new Date() })
+            const s2 = await db.save({ name: `${label}_batch_get`, type: 'text/plain', url: '/g2.txt', date: new Date() })
+            const records = await db.getByIdsBatch([{ id: String(s1.id), name: `${label}_batch_get` }, { id: String(s2.id), name: `${label}_batch_get` }])
+            assert.lengthOf(records, 2)
+        })
+    })
+
+    test.group(`KyselyDatabaseAdapter [${label}] - Asset Operations`, group => {
+        let db: KyselyDatabaseAdapter
+        let cleanup: () => Promise<void>
+
+        group.setup(async () => {
+            const result = await factory()
+            db = result.db
+            cleanup = result.cleanup
+            await db.createTable(`${label}_assets`)
+            for (let i = 0; i < 5; i++) {
+                await db.save({ name: `${label}_assets`, type: 'text/plain', url: `/a${i}.txt`, date: new Date() })
+            }
+        })
+        group.teardown(async () => { await cleanup() })
+
+        test('getAllAssetsPaginated returns records with total count', async ({ assert }) => {
+            const { records, total } = await db.getAllAssetsPaginated(`${label}_assets`, 0, 3)
+            assert.equal(total, 5)
+            assert.lengthOf(records, 3)
+        })
+
+        test('getAllAssetsPaginated respects offset', async ({ assert }) => {
+            const { records } = await db.getAllAssetsPaginated(`${label}_assets`, 3, 10)
+            assert.lengthOf(records, 2)
+        })
+
+        test('updateAssetMetadata updates specified fields', async ({ assert }) => {
+            const saved = await db.save({ name: `${label}_assets`, type: 'text/plain', url: '/upd.txt', date: new Date(), description: 'Original' })
+            const updated = await db.updateAssetMetadata(`${label}_assets`, saved.id, { description: 'Updated' })
+            assert.equal(updated.id, saved.id)
+        })
+
+        test('updateAssetMetadata throws for non-existent record', async ({ assert }) => {
+            await assert.rejects(() => db.updateAssetMetadata(`${label}_assets`, 99999, { description: 'Test' }), /not found/i)
+        })
+    })
+
+    test.group(`KyselyDatabaseAdapter [${label}] - Custom Table Operations`, group => {
+        let db: KyselyDatabaseAdapter
+        let cleanup: () => Promise<void>
+
+        group.setup(async () => {
+            const result = await factory()
+            db = result.db
+            cleanup = result.cleanup
+        })
+        group.teardown(async () => { await cleanup() })
+
+        test('createTableWithColumns creates table with custom columns', async ({ assert }) => {
+            await db.createTableWithColumns(`${label}_custom`, { sensor_id: 'text not null', temperature: 'real', description: 'varchar(255)' })
+            assert.isTrue(await db.doesTableExists(`${label}_custom`))
+        })
+
+        test('insertCustomTableRecord inserts and returns ID', async ({ assert }) => {
+            await db.createTableWithColumns(`${label}_insert`, { name: 'text not null', value: 'integer' })
+            const id = await db.insertCustomTableRecord(`${label}_insert`, { name: 'Test', value: 42 })
+            assert.isNumber(id)
+            assert.isTrue(id > 0)
+        })
+
+        test('getCustomTableRecordById retrieves record', async ({ assert }) => {
+            await db.createTableWithColumns(`${label}_getbyid_ct`, { name: 'text not null' })
+            const id = await db.insertCustomTableRecord(`${label}_getbyid_ct`, { name: 'Test' })
+            const record = await db.getCustomTableRecordById(`${label}_getbyid_ct`, id)
+            assert.isNotNull(record)
+            assert.equal(record.name, 'Test')
+        })
+
+        test('getCustomTableRecordById returns null for non-existent', async ({ assert }) => {
+            await db.createTableWithColumns(`${label}_null_ct`, { name: 'text not null' })
+            assert.isNull(await db.getCustomTableRecordById(`${label}_null_ct`, 99999))
+        })
+
+        test('findCustomTableRecords finds records by conditions', async ({ assert }) => {
+            await db.createTableWithColumns(`${label}_find`, { category: 'text' })
+            await db.insertCustomTableRecord(`${label}_find`, { category: 'A' })
+            await db.insertCustomTableRecord(`${label}_find`, { category: 'B' })
+            await db.insertCustomTableRecord(`${label}_find`, { category: 'A' })
+            const records = await db.findCustomTableRecords(`${label}_find`, { category: 'A' })
+            assert.lengthOf(records, 2)
+        })
+
+        test('updateById updates record', async ({ assert }) => {
+            await db.createTableWithColumns(`${label}_update`, { name: 'text not null', status: 'text' })
+            const id = await db.insertCustomTableRecord(`${label}_update`, { name: 'Original', status: 'pending' })
+            await db.updateById(`${label}_update`, id, { name: 'Updated', status: 'completed' })
+            const record = await db.getCustomTableRecordById(`${label}_update`, id)
+            assert.equal(record.name, 'Updated')
+        })
+
+        test('updateById throws for non-existent record', async ({ assert }) => {
+            await db.createTableWithColumns(`${label}_update_fail`, { name: 'text not null' })
+            await assert.rejects(() => db.updateById(`${label}_update_fail`, 99999, { name: 'Test' }), /No record found/)
+        })
+    })
+
+    test.group(`KyselyDatabaseAdapter [${label}] - Table Name Validation`, group => {
+        let db: KyselyDatabaseAdapter
+        let cleanup: () => Promise<void>
+
+        group.setup(async () => {
+            const result = await factory()
+            db = result.db
+            cleanup = result.cleanup
+        })
+        group.teardown(async () => { await cleanup() })
+
+        test('rejects table name with SQL injection', async ({ assert }) => {
+            await assert.rejects(() => db.createTable('users; DROP TABLE important--'), /Invalid table name/)
+        })
+
+        test('rejects table name starting with number', async ({ assert }) => {
+            await assert.rejects(() => db.createTable('123table'), /Invalid table name/)
+        })
+
+        test('rejects excessively long table name', async ({ assert }) => {
+            await assert.rejects(() => db.createTable('a'.repeat(64)), /Table name too long/)
+        })
+
+        test('accepts valid table names', async ({ assert }) => {
+            await db.doesTableExists('valid_table')
+            await db.doesTableExists('_private')
+            assert.isTrue(true)
+        })
+    })
+
+    test.group(`KyselyDatabaseAdapter [${label}] - ensureColumns`, group => {
+        let db: KyselyDatabaseAdapter
+        let cleanup: () => Promise<void>
+
+        group.setup(async () => {
+            const result = await factory()
+            db = result.db
+            cleanup = result.cleanup
+        })
+        group.teardown(async () => { await cleanup() })
+
+        test('ensureColumns adds missing columns to existing table', async ({ assert }) => {
+            await db.createTableWithColumns(`${label}_ensure`, { sensor_id: 'text not null' })
+            await db.ensureColumns(`${label}_ensure`, { sensor_id: 'text not null', temperature: 'real' })
+            const tables = await db.getKysely().introspection.getTables()
+            const table = tables.find(t => t.name === `${label}_ensure`)
+            assert.include(table!.columns.map(c => c.name), 'temperature')
+        })
+
+        test('ensureColumns is a no-op when all columns exist', async ({ assert }) => {
+            await db.createTableWithColumns(`${label}_ensure_noop`, { sensor_id: 'text not null' })
+            await assert.doesNotReject(() => db.ensureColumns(`${label}_ensure_noop`, { sensor_id: 'text not null' }))
+        })
+
+        test('migrateTableSchema is idempotent on current schema', async ({ assert }) => {
+            await db.createTable(`${label}_migrate_idem`)
+            await db.migrateTableSchema(`${label}_migrate_idem`)
+            assert.lengthOf(await db.migrateTableSchema(`${label}_migrate_idem`), 0)
+        })
+
+        test('migrateTableSchema returns empty for non-existent table', async ({ assert }) => {
+            assert.lengthOf(await db.migrateTableSchema('non_existent_xyz'), 0)
+        })
+    })
+
+    // SQLite-specific: uses autoIncrement + datetime (SQLite-only syntax)
+    if (label === 'sl') {
+        test.group('KyselyDatabaseAdapter [SQLite] - migrateTableSchema (legacy)', group => {
+            let db: KyselyDatabaseAdapter
+            let cleanup: () => Promise<void>
+
+            group.setup(async () => {
+                const result = await factory()
+                db = result.db
+                cleanup = result.cleanup
+            })
+            group.teardown(async () => { await cleanup() })
+
+            test('migrateTableSchema adds missing columns to legacy table', async ({ assert }) => {
+                const kysely = db.getKysely()
+                await kysely.schema
+                    .createTable('migrate_legacy_sqlite')
+                    .addColumn('id', 'integer', col => col.primaryKey().autoIncrement())
+                    .addColumn('name', 'varchar(255)', col => col.notNull())
+                    .addColumn('type', 'varchar(255)', col => col.notNull())
+                    .addColumn('url', 'varchar(255)', col => col.notNull())
+                    .addColumn('date', 'datetime', col => col.notNull())
+                    .execute()
+                const migrations = await db.migrateTableSchema('migrate_legacy_sqlite')
+                assert.isTrue(migrations.length > 0)
+                assert.isTrue(migrations.some(m => m.includes('is_public')))
+            })
+        })
+    } else {
+        test.group('KyselyDatabaseAdapter [PostgreSQL] - migrateTableSchema (legacy)', group => {
+            let db: KyselyDatabaseAdapter
+            let cleanup: () => Promise<void>
+
+            group.setup(async () => {
+                const result = await factory()
+                db = result.db
+                cleanup = result.cleanup
+            })
+            group.teardown(async () => { await cleanup() })
+
+            test('migrateTableSchema adds missing columns to legacy table', async ({ assert }) => {
+                await sql`
+                    CREATE TABLE migrate_legacy_pg (
+                        id SERIAL PRIMARY KEY,
+                        name VARCHAR(255) NOT NULL,
+                        type VARCHAR(255) NOT NULL,
+                        url VARCHAR(255) NOT NULL,
+                        date TIMESTAMPTZ NOT NULL
+                    )
+                `.execute(db.getKysely())
+                const migrations = await db.migrateTableSchema('migrate_legacy_pg')
+                assert.isTrue(migrations.length > 0)
+                assert.isTrue(migrations.some(m => m.includes('is_public')))
+            })
+        })
     }
-
-    return { db, cleanup }
 }
 
-test.group('KyselyDatabaseAdapter - Basic Operations', (group) => {
-    let db: KyselyDatabaseAdapter
-    let cleanup: () => Promise<void>
-
-    group.setup(async () => {
-        const result = createTestDb()
-        db = result.db
-        cleanup = result.cleanup
-    })
-
-    group.teardown(async () => {
-        await cleanup()
-    })
-
-    test('createTable creates table with expected columns', async ({ assert }) => {
-        await db.createTable('test_basic')
-        const exists = await db.doesTableExists('test_basic')
-        assert.isTrue(exists)
-    })
-
-    test('save inserts a record and returns it with ID', async ({ assert }) => {
-        await db.createTable('test_save')
-
-        const record = await db.save({
-            name: 'test_save',
-            type: 'application/json',
-            url: '/test/file.json',
-            date: new Date()
-        })
-
-        assert.isDefined(record.id)
-        assert.equal(record.name, 'test_save')
-        assert.equal(record.contentType, 'application/json')
-    })
-
-    test('getById retrieves record by ID', async ({ assert }) => {
-        await db.createTable('test_getbyid')
-
-        const saved = await db.save({
-            name: 'test_getbyid',
-            type: 'text/plain',
-            url: '/test.txt',
-            date: new Date()
-        })
-
-        const fetched = await db.getById(String(saved.id), 'test_getbyid')
-        assert.isDefined(fetched)
-        assert.equal(fetched!.id, saved.id)
-    })
-
-    test('getById returns undefined for non-existent ID', async ({ assert }) => {
-        await db.createTable('test_getbyid_none')
-        const fetched = await db.getById('99999', 'test_getbyid_none')
-        assert.isUndefined(fetched)
-    })
-
-    test('delete removes a record', async ({ assert }) => {
-        await db.createTable('test_delete')
-        const saved = await db.save({
-            name: 'test_delete',
-            type: 'text/plain',
-            url: '/test.txt',
-            date: new Date()
-        })
-
-        await db.delete(String(saved.id), 'test_delete')
-        const fetched = await db.getById(String(saved.id), 'test_delete')
-        assert.isUndefined(fetched)
-    })
-
-    test('getLatestByName returns most recent record', async ({ assert }) => {
-        await db.createTable('test_latest')
-
-        await db.save({ name: 'test_latest', type: 'text/plain', url: '/old.txt', date: new Date('2024-01-01') })
-        await db.save({ name: 'test_latest', type: 'text/plain', url: '/new.txt', date: new Date('2024-06-01') })
-
-        const latest = await db.getLatestByName('test_latest')
-        assert.isDefined(latest)
-        assert.equal(latest!.url, '/new.txt')
-    })
-
-    test('doesTableExists returns false for non-existent table', async ({ assert }) => {
-        const exists = await db.doesTableExists('non_existent_table')
-        assert.isFalse(exists)
-    })
-})
-
-test.group('KyselyDatabaseAdapter - Extended Queries', (group) => {
-    let db: KyselyDatabaseAdapter
-    let cleanup: () => Promise<void>
-
-    group.setup(async () => {
-        const result = createTestDb()
-        db = result.db
-        cleanup = result.cleanup
-
-        await db.createTable('test_queries')
-        const dates = [
-            new Date('2024-01-15'),
-            new Date('2024-02-15'),
-            new Date('2024-03-15'),
-            new Date('2024-04-15'),
-            new Date('2024-05-15')
-        ]
-
-        for (let i = 0; i < dates.length; i++) {
-            await db.save({
-                name: 'test_queries',
-                type: 'text/plain',
-                url: `/file${i + 1}.txt`,
-                date: dates[i]
-            })
-        }
-    })
-
-    group.teardown(async () => {
-        await cleanup()
-    })
-
-    test('getFirstByName returns oldest record', async ({ assert }) => {
-        const first = await db.getFirstByName('test_queries')
-        assert.isDefined(first)
-        assert.equal(first!.url, '/file1.txt')
-    })
-
-    test('getByDateRange returns records in range', async ({ assert }) => {
-        const records = await db.getByDateRange('test_queries', new Date('2024-02-01'), new Date('2024-04-01'))
-        assert.lengthOf(records, 2)
-        assert.equal(records[0].url, '/file2.txt')
-        assert.equal(records[1].url, '/file3.txt')
-    })
-
-    test('getByDateRange with limit restricts results', async ({ assert }) => {
-        const records = await db.getByDateRange('test_queries', new Date('2024-01-01'), undefined, 2)
-        assert.lengthOf(records, 2)
-    })
-
-    test('getByDateRange with desc order returns newest first', async ({ assert }) => {
-        const records = await db.getByDateRange('test_queries', new Date('2024-01-01'), new Date('2024-06-01'), undefined, 'desc')
-        assert.lengthOf(records, 5)
-        assert.equal(records[0].url, '/file5.txt')
-        assert.equal(records[4].url, '/file1.txt')
-    })
-
-    test('getAfterDate returns records after date', async ({ assert }) => {
-        const records = await db.getAfterDate('test_queries', new Date('2024-04-01'))
-        assert.lengthOf(records, 2)
-        assert.equal(records[0].url, '/file4.txt')
-    })
-
-    test('getLatestBefore returns most recent before date', async ({ assert }) => {
-        const record = await db.getLatestBefore('test_queries', new Date('2024-03-20'))
-        assert.isDefined(record)
-        assert.equal(record!.url, '/file3.txt')
-    })
-
-    test('getLatestRecordsBefore returns multiple records', async ({ assert }) => {
-        const records = await db.getLatestRecordsBefore('test_queries', new Date('2024-05-01'), 2)
-        assert.lengthOf(records, 2)
-        assert.equal(records[0].url, '/file4.txt')
-        assert.equal(records[1].url, '/file3.txt')
-    })
-
-    test('hasRecordsAfterDate returns true when records exist', async ({ assert }) => {
-        assert.isTrue(await db.hasRecordsAfterDate('test_queries', new Date('2024-04-01')))
-    })
-
-    test('hasRecordsAfterDate returns false when no records', async ({ assert }) => {
-        assert.isFalse(await db.hasRecordsAfterDate('test_queries', new Date('2025-01-01')))
-    })
-
-    test('countByDateRange counts records correctly', async ({ assert }) => {
-        const count = await db.countByDateRange('test_queries', new Date('2024-02-01'), new Date('2024-05-01'))
-        assert.equal(count, 3)
-    })
-})
-
-test.group('KyselyDatabaseAdapter - Batch Operations', (group) => {
-    let db: KyselyDatabaseAdapter
-    let cleanup: () => Promise<void>
-
-    group.setup(async () => {
-        const result = createTestDb()
-        db = result.db
-        cleanup = result.cleanup
-    })
-
-    group.teardown(async () => {
-        await cleanup()
-    })
-
-    test('saveBatch inserts multiple records', async ({ assert }) => {
-        await db.createTable('test_batch_save')
-        const metadata = [
-            { name: 'test_batch_save', type: 'text/plain', url: '/b1.txt', date: new Date() },
-            { name: 'test_batch_save', type: 'text/plain', url: '/b2.txt', date: new Date() },
-            { name: 'test_batch_save', type: 'text/plain', url: '/b3.txt', date: new Date() }
-        ]
-
-        const records = await db.saveBatch(metadata)
-        assert.lengthOf(records, 3)
-
-        const count = await db.countByDateRange('test_batch_save', new Date('2020-01-01'))
-        assert.equal(count, 3)
-    })
-
-    test('saveBatch returns empty array for empty input', async ({ assert }) => {
-        assert.lengthOf(await db.saveBatch([]), 0)
-    })
-
-    test('deleteBatch removes multiple records', async ({ assert }) => {
-        await db.createTable('test_batch_delete')
-        const s1 = await db.save({ name: 'test_batch_delete', type: 'text/plain', url: '/d1.txt', date: new Date() })
-        const s2 = await db.save({ name: 'test_batch_delete', type: 'text/plain', url: '/d2.txt', date: new Date() })
-
-        await db.deleteBatch([
-            { id: String(s1.id), name: 'test_batch_delete' },
-            { id: String(s2.id), name: 'test_batch_delete' }
-        ])
-
-        assert.equal(await db.countByDateRange('test_batch_delete', new Date('2020-01-01')), 0)
-    })
-
-    test('deleteBatch does nothing for empty input', async ({ assert }) => {
-        await assert.doesNotThrow(() => db.deleteBatch([]))
-    })
-
-    test('getByIdsBatch retrieves multiple records', async ({ assert }) => {
-        await db.createTable('test_batch_get')
-        const s1 = await db.save({ name: 'test_batch_get', type: 'text/plain', url: '/g1.txt', date: new Date() })
-        const s2 = await db.save({ name: 'test_batch_get', type: 'text/plain', url: '/g2.txt', date: new Date() })
-
-        const records = await db.getByIdsBatch([
-            { id: String(s1.id), name: 'test_batch_get' },
-            { id: String(s2.id), name: 'test_batch_get' }
-        ])
-        assert.lengthOf(records, 2)
-    })
-})
-
-test.group('KyselyDatabaseAdapter - Asset Operations', (group) => {
-    let db: KyselyDatabaseAdapter
-    let cleanup: () => Promise<void>
-
-    group.setup(async () => {
-        const result = createTestDb()
-        db = result.db
-        cleanup = result.cleanup
-        await db.createTable('test_assets')
-
-        for (let i = 0; i < 5; i++) {
-            await db.save({ name: 'test_assets', type: 'text/plain', url: `/a${i}.txt`, date: new Date() })
-        }
-    })
-
-    group.teardown(async () => {
-        await cleanup()
-    })
-
-    test('getAllAssetsPaginated returns records with total count', async ({ assert }) => {
-        const { records, total } = await db.getAllAssetsPaginated('test_assets', 0, 3)
-        assert.equal(total, 5)
-        assert.lengthOf(records, 3)
-    })
-
-    test('getAllAssetsPaginated respects offset', async ({ assert }) => {
-        const { records } = await db.getAllAssetsPaginated('test_assets', 3, 10)
-        assert.lengthOf(records, 2)
-    })
-
-    test('updateAssetMetadata updates specified fields', async ({ assert }) => {
-        const saved = await db.save({
-            name: 'test_assets',
-            type: 'text/plain',
-            url: '/upd.txt',
-            date: new Date(),
-            description: 'Original',
-            is_public: true
-        })
-
-        const updated = await db.updateAssetMetadata('test_assets', saved.id, {
-            description: 'Updated',
-            is_public: false
-        })
-        assert.equal(updated.id, saved.id)
-    })
-
-    test('updateAssetMetadata throws for non-existent record', async ({ assert }) => {
-        await assert.rejects(
-            () => db.updateAssetMetadata('test_assets', 99999, { description: 'Test' }),
-            /not found/
-        )
-    })
-})
-
-test.group('KyselyDatabaseAdapter - Custom Table Operations', (group) => {
-    let db: KyselyDatabaseAdapter
-    let cleanup: () => Promise<void>
-
-    group.setup(async () => {
-        const result = createTestDb()
-        db = result.db
-        cleanup = result.cleanup
-    })
-
-    group.teardown(async () => {
-        await cleanup()
-    })
-
-    test('createTableWithColumns creates table with custom columns', async ({ assert }) => {
-        await db.createTableWithColumns('custom_test', {
-            sensor_id: 'text not null',
-            temperature: 'real',
-            active: 'boolean default true',
-            description: 'varchar(255)'
-        })
-
-        assert.isTrue(await db.doesTableExists('custom_test'))
-    })
-
-    test('insertCustomTableRecord inserts and returns ID', async ({ assert }) => {
-        await db.createTableWithColumns('custom_insert', { name: 'text not null', value: 'integer' })
-        const id = await db.insertCustomTableRecord('custom_insert', { name: 'Test', value: 42 })
-        assert.isNumber(id)
-        assert.isTrue(id > 0)
-    })
-
-    test('getCustomTableRecordById retrieves record', async ({ assert }) => {
-        await db.createTableWithColumns('custom_getbyid', { name: 'text not null' })
-        const id = await db.insertCustomTableRecord('custom_getbyid', { name: 'Test' })
-
-        const record = await db.getCustomTableRecordById('custom_getbyid', id)
-        assert.isNotNull(record)
-        assert.equal(record.name, 'Test')
-    })
-
-    test('getCustomTableRecordById returns null for non-existent', async ({ assert }) => {
-        await db.createTableWithColumns('custom_getbyid_null', { name: 'text not null' })
-        assert.isNull(await db.getCustomTableRecordById('custom_getbyid_null', 99999))
-    })
-
-    test('findCustomTableRecords finds records by conditions', async ({ assert }) => {
-        await db.createTableWithColumns('custom_find', { category: 'text', active: 'boolean default true' })
-        await db.insertCustomTableRecord('custom_find', { category: 'A', active: true })
-        await db.insertCustomTableRecord('custom_find', { category: 'B', active: true })
-        await db.insertCustomTableRecord('custom_find', { category: 'A', active: false })
-
-        const records = await db.findCustomTableRecords('custom_find', { category: 'A' })
-        assert.lengthOf(records, 2)
-    })
-
-    test('findByConditions works with null values', async ({ assert }) => {
-        await db.createTableWithColumns('custom_null', { optional_field: 'text' })
-        await db.insertCustomTableRecord('custom_null', { optional_field: null })
-        await db.insertCustomTableRecord('custom_null', { optional_field: 'value' })
-
-        const records = await db.findByConditions('custom_null', { optional_field: null })
-        assert.lengthOf(records, 1)
-    })
-
-    test('updateById updates record', async ({ assert }) => {
-        await db.createTableWithColumns('custom_update', { name: 'text not null', status: 'text' })
-        const id = await db.insertCustomTableRecord('custom_update', { name: 'Original', status: 'pending' })
-
-        await db.updateById('custom_update', id, { name: 'Updated', status: 'completed' })
-
-        const record = await db.getCustomTableRecordById('custom_update', id)
-        assert.equal(record.name, 'Updated')
-        assert.equal(record.status, 'completed')
-    })
-
-    test('updateById throws for non-existent record', async ({ assert }) => {
-        await db.createTableWithColumns('custom_update_fail', { name: 'text not null' })
-        await assert.rejects(() => db.updateById('custom_update_fail', 99999, { name: 'Test' }), /No record found/)
-    })
-})
-
-test.group('KyselyDatabaseAdapter - Table Name Validation', (group) => {
-    let db: KyselyDatabaseAdapter
-    let cleanup: () => Promise<void>
-
-    group.setup(async () => {
-        const result = createTestDb()
-        db = result.db
-        cleanup = result.cleanup
-    })
-
-    group.teardown(async () => {
-        await cleanup()
-    })
-
-    test('rejects table name with SQL injection', async ({ assert }) => {
-        await assert.rejects(() => db.createTable('users; DROP TABLE important--'), /Invalid table name/)
-    })
-
-    test('rejects table name starting with number', async ({ assert }) => {
-        await assert.rejects(() => db.createTable('123table'), /Invalid table name/)
-    })
-
-    test('rejects excessively long table name', async ({ assert }) => {
-        await assert.rejects(() => db.createTable('a'.repeat(64)), /Table name too long/)
-    })
-
-    test('accepts valid table names', async ({ assert }) => {
-        // Use doesTableExists (which also validates) to avoid async index creation during teardown
-        await db.doesTableExists('valid_table')
-        await db.doesTableExists('_private')
-        await db.doesTableExists('Table123')
-        // If we got here without throwing, validation passed
-        assert.isTrue(true)
-    })
-})
-
-test.group('KyselyDatabaseAdapter - Schema Migration', (group) => {
-    let db: KyselyDatabaseAdapter
-    let cleanup: () => Promise<void>
-
-    group.setup(async () => {
-        const result = createTestDb()
-        db = result.db
-        cleanup = result.cleanup
-    })
-
-    group.teardown(async () => {
-        await cleanup()
-    })
-
-    test('migrateTableSchema adds missing columns', async ({ assert }) => {
-        // Create minimal table manually (simulating old schema)
-        const kysely = db.getKysely()
-        await kysely.schema
-            .createTable('migrate_test')
-            .addColumn('id', 'integer', col => col.primaryKey().autoIncrement())
-            .addColumn('name', 'varchar(255)', col => col.notNull())
-            .addColumn('type', 'varchar(255)', col => col.notNull())
-            .addColumn('url', 'varchar(255)', col => col.notNull())
-            .addColumn('date', 'datetime', col => col.notNull())
-            .execute()
-
-        const migrations = await db.migrateTableSchema('migrate_test')
-
-        assert.isTrue(migrations.length > 0)
-        assert.isTrue(migrations.some(m => m.includes('is_public')))
-    })
-
-    test('migrateTableSchema returns empty for non-existent table', async ({ assert }) => {
-        const migrations = await db.migrateTableSchema('non_existent')
-        assert.lengthOf(migrations, 0)
-    })
-
-    test('migrateTableSchema is idempotent', async ({ assert }) => {
-        await db.createTable('migrate_idempotent')
-        await db.migrateTableSchema('migrate_idempotent')
-        const migrations2 = await db.migrateTableSchema('migrate_idempotent')
-        assert.lengthOf(migrations2, 0)
-    })
-})
+registerAdapterTests('sl', sqliteAdapterFactory)
+
+if (pgAvailable) {
+    registerAdapterTests('pg', postgresAdapterFactory)
+}

--- a/packages/database/tests/kysely_user_repository.spec.ts
+++ b/packages/database/tests/kysely_user_repository.spec.ts
@@ -9,10 +9,11 @@ function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
     test.group(`KyselyUserRepository [${label}]`, group => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let db: Kysely<any>
+        let dialect: 'postgres' | 'sqlite'
         let cleanup: () => Promise<void>
 
         group.each.setup(async () => {
-            ({ db, cleanup } = await factory())
+            ({ db, dialect, cleanup } = await factory())
         })
 
         group.each.teardown(async () => {
@@ -20,7 +21,7 @@ function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
         })
 
         test('initializeTables() creates users, roles, user_roles tables', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             const tables = await db.introspection.getTables()
             const names = tables.map((t: { name: string }) => t.name)
@@ -30,7 +31,7 @@ function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
         })
 
         test('initializeTables() is idempotent', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             await repo.initializeTables()
             const tables = await db.introspection.getTables()
@@ -38,7 +39,7 @@ function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
         })
 
         test('findOrCreateUser() creates a new user with ID', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             const authUser: AuthenticatedUser = { id: 'keycloak-uuid-1', roles: ['user'] }
             const result = await repo.findOrCreateUser(authUser)
@@ -48,7 +49,7 @@ function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
         })
 
         test('findOrCreateUser() returns existing user for same keycloak_id', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             const authUser: AuthenticatedUser = { id: 'keycloak-uuid-2', roles: ['user'] }
             const first = await repo.findOrCreateUser(authUser)
@@ -57,7 +58,7 @@ function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
         })
 
         test('findOrCreateUser() synchronizes roles (add + remove)', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             const authUser: AuthenticatedUser = { id: 'keycloak-uuid-3', roles: ['user', 'editor'] }
             const first = await repo.findOrCreateUser(authUser)
@@ -69,7 +70,7 @@ function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
         })
 
         test('findOrCreateUser() with empty roles clears all roles', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             await repo.findOrCreateUser({ id: 'keycloak-uuid-4', roles: ['user', 'admin'] })
             const result = await repo.findOrCreateUser({ id: 'keycloak-uuid-4', roles: [] })
@@ -77,7 +78,7 @@ function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
         })
 
         test('getUserById() returns user with roles', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             const created = await repo.findOrCreateUser({ id: 'keycloak-uuid-5', roles: ['user', 'admin'] })
             const result = await repo.getUserById(created.id!)
@@ -87,13 +88,13 @@ function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
         })
 
         test('getUserById() returns undefined when not found', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             assert.isUndefined(await repo.getUserById(99999))
         })
 
         test('getUserByKeycloakId() returns user with roles', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             await repo.findOrCreateUser({ id: 'keycloak-uuid-6', roles: ['editor'] })
             const result = await repo.getUserByKeycloakId('keycloak-uuid-6')
@@ -102,13 +103,13 @@ function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
         })
 
         test('getUserByKeycloakId() returns undefined when not found', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             assert.isUndefined(await repo.getUserByKeycloakId('nonexistent'))
         })
 
         test('keycloak_id uniqueness constraint', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             await db.insertInto('users').values({ keycloak_id: 'dup-id', created_at: new Date().toISOString(), updated_at: new Date().toISOString() }).execute()
             // Both SQLite ("UNIQUE constraint failed") and PG ("duplicate key") throw on duplicate
@@ -119,7 +120,7 @@ function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
         })
 
         test('timestamps are set on creation', async ({ assert }) => {
-            const repo = new KyselyUserRepository(db)
+            const repo = new KyselyUserRepository(db, dialect)
             await repo.initializeTables()
             const before = new Date()
             const result = await repo.findOrCreateUser({ id: 'keycloak-uuid-7', roles: ['user'] })

--- a/packages/database/tests/kysely_user_repository.spec.ts
+++ b/packages/database/tests/kysely_user_repository.spec.ts
@@ -1,165 +1,139 @@
 import { test } from '@japa/runner'
-import Database from 'better-sqlite3'
-import { Kysely, SqliteDialect } from 'kysely'
 import { KyselyUserRepository } from '../src/kysely_user_repository.js'
+import { sqliteKyselyFactory, postgresKyselyFactory } from './helpers/factories.js'
+import type { KyselyFactory } from './helpers/factories.js'
 import type { AuthenticatedUser } from '@digitaltwin/shared'
+import type { Kysely } from 'kysely'
 
-function createDb() {
-    const sqliteDb = new Database(':memory:')
-    const db = new Kysely<any>({
-        dialect: new SqliteDialect({ database: sqliteDb })
+function registerUserRepositoryTests(label: string, factory: KyselyFactory) {
+    test.group(`KyselyUserRepository [${label}]`, group => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let db: Kysely<any>
+        let cleanup: () => Promise<void>
+
+        group.each.setup(async () => {
+            ({ db, cleanup } = await factory())
+        })
+
+        group.each.teardown(async () => {
+            await cleanup()
+        })
+
+        test('initializeTables() creates users, roles, user_roles tables', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            const tables = await db.introspection.getTables()
+            const names = tables.map((t: { name: string }) => t.name)
+            assert.include(names, 'users')
+            assert.include(names, 'roles')
+            assert.include(names, 'user_roles')
+        })
+
+        test('initializeTables() is idempotent', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            await repo.initializeTables()
+            const tables = await db.introspection.getTables()
+            assert.isTrue(tables.some((t: { name: string }) => t.name === 'users'))
+        })
+
+        test('findOrCreateUser() creates a new user with ID', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            const authUser: AuthenticatedUser = { id: 'keycloak-uuid-1', roles: ['user'] }
+            const result = await repo.findOrCreateUser(authUser)
+            assert.isDefined(result.id)
+            assert.isNumber(result.id)
+            assert.equal(result.keycloak_id, 'keycloak-uuid-1')
+        })
+
+        test('findOrCreateUser() returns existing user for same keycloak_id', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            const authUser: AuthenticatedUser = { id: 'keycloak-uuid-2', roles: ['user'] }
+            const first = await repo.findOrCreateUser(authUser)
+            const second = await repo.findOrCreateUser(authUser)
+            assert.equal(first.id, second.id)
+        })
+
+        test('findOrCreateUser() synchronizes roles (add + remove)', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            const authUser: AuthenticatedUser = { id: 'keycloak-uuid-3', roles: ['user', 'editor'] }
+            const first = await repo.findOrCreateUser(authUser)
+            assert.includeMembers(first.roles, ['user', 'editor'])
+            authUser.roles = ['user', 'admin']
+            const second = await repo.findOrCreateUser(authUser)
+            assert.includeMembers(second.roles, ['user', 'admin'])
+            assert.notInclude(second.roles, 'editor')
+        })
+
+        test('findOrCreateUser() with empty roles clears all roles', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            await repo.findOrCreateUser({ id: 'keycloak-uuid-4', roles: ['user', 'admin'] })
+            const result = await repo.findOrCreateUser({ id: 'keycloak-uuid-4', roles: [] })
+            assert.deepEqual(result.roles, [])
+        })
+
+        test('getUserById() returns user with roles', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            const created = await repo.findOrCreateUser({ id: 'keycloak-uuid-5', roles: ['user', 'admin'] })
+            const result = await repo.getUserById(created.id!)
+            assert.isDefined(result)
+            assert.equal(result!.id, created.id)
+            assert.includeMembers(result!.roles, ['user', 'admin'])
+        })
+
+        test('getUserById() returns undefined when not found', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            assert.isUndefined(await repo.getUserById(99999))
+        })
+
+        test('getUserByKeycloakId() returns user with roles', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            await repo.findOrCreateUser({ id: 'keycloak-uuid-6', roles: ['editor'] })
+            const result = await repo.getUserByKeycloakId('keycloak-uuid-6')
+            assert.isDefined(result)
+            assert.includeMembers(result!.roles, ['editor'])
+        })
+
+        test('getUserByKeycloakId() returns undefined when not found', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            assert.isUndefined(await repo.getUserByKeycloakId('nonexistent'))
+        })
+
+        test('keycloak_id uniqueness constraint', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            await db.insertInto('users').values({ keycloak_id: 'dup-id', created_at: new Date().toISOString(), updated_at: new Date().toISOString() }).execute()
+            // Both SQLite ("UNIQUE constraint failed") and PG ("duplicate key") throw on duplicate
+            await assert.rejects(
+                () => db.insertInto('users').values({ keycloak_id: 'dup-id', created_at: new Date().toISOString(), updated_at: new Date().toISOString() }).execute(),
+                /unique|duplicate/i
+            )
+        })
+
+        test('timestamps are set on creation', async ({ assert }) => {
+            const repo = new KyselyUserRepository(db)
+            await repo.initializeTables()
+            const before = new Date()
+            const result = await repo.findOrCreateUser({ id: 'keycloak-uuid-7', roles: ['user'] })
+            const after = new Date()
+            assert.instanceOf(result.created_at, Date)
+            assert.instanceOf(result.updated_at, Date)
+            assert.isTrue(result.created_at! >= before)
+            assert.isTrue(result.updated_at! <= after)
+        })
     })
-    return { db, sqliteDb }
 }
 
-test.group('KyselyUserRepository', (group) => {
-    let db: Kysely<any>
-    let sqliteDb: InstanceType<typeof Database>
+registerUserRepositoryTests('SQLite', sqliteKyselyFactory)
 
-    group.each.setup(() => {
-        const result = createDb()
-        db = result.db
-        sqliteDb = result.sqliteDb
-    })
-
-    group.each.teardown(async () => {
-        await db.destroy()
-    })
-
-    test('initializeTables() creates users, roles, user_roles tables', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-        await repo.initializeTables()
-
-        const tables = await db.introspection.getTables()
-        const names = tables.map(t => t.name)
-        assert.include(names, 'users')
-        assert.include(names, 'roles')
-        assert.include(names, 'user_roles')
-    })
-
-    test('initializeTables() is idempotent', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-
-        await repo.initializeTables()
-        await repo.initializeTables()
-
-        const tables = await db.introspection.getTables()
-        assert.isTrue(tables.some(t => t.name === 'users'))
-    })
-
-    test('findOrCreateUser() creates a new user with ID', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-        await repo.initializeTables()
-
-        const authUser: AuthenticatedUser = { id: 'keycloak-uuid-1', roles: ['user'] }
-        const result = await repo.findOrCreateUser(authUser)
-
-        assert.isDefined(result.id)
-        assert.isNumber(result.id)
-        assert.equal(result.keycloak_id, 'keycloak-uuid-1')
-    })
-
-    test('findOrCreateUser() returns existing user for same keycloak_id', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-        await repo.initializeTables()
-
-        const authUser: AuthenticatedUser = { id: 'keycloak-uuid-2', roles: ['user'] }
-        const first = await repo.findOrCreateUser(authUser)
-        const second = await repo.findOrCreateUser(authUser)
-
-        assert.equal(first.id, second.id)
-        assert.equal(second.keycloak_id, 'keycloak-uuid-2')
-    })
-
-    test('findOrCreateUser() synchronizes roles (add + remove)', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-        await repo.initializeTables()
-
-        const authUser: AuthenticatedUser = { id: 'keycloak-uuid-3', roles: ['user', 'editor'] }
-        const first = await repo.findOrCreateUser(authUser)
-        assert.includeMembers(first.roles, ['user', 'editor'])
-
-        // Update roles: remove editor, add admin
-        authUser.roles = ['user', 'admin']
-        const second = await repo.findOrCreateUser(authUser)
-        assert.includeMembers(second.roles, ['user', 'admin'])
-        assert.notInclude(second.roles, 'editor')
-    })
-
-    test('findOrCreateUser() with empty roles clears all roles', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-        await repo.initializeTables()
-
-        await repo.findOrCreateUser({ id: 'keycloak-uuid-4', roles: ['user', 'admin'] })
-        const result = await repo.findOrCreateUser({ id: 'keycloak-uuid-4', roles: [] })
-
-        assert.deepEqual(result.roles, [])
-    })
-
-    test('getUserById() returns user with roles', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-        await repo.initializeTables()
-
-        const created = await repo.findOrCreateUser({ id: 'keycloak-uuid-5', roles: ['user', 'admin'] })
-        const result = await repo.getUserById(created.id!)
-
-        assert.isDefined(result)
-        assert.equal(result!.id, created.id)
-        assert.equal(result!.keycloak_id, 'keycloak-uuid-5')
-        assert.includeMembers(result!.roles, ['user', 'admin'])
-    })
-
-    test('getUserById() returns undefined when not found', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-        await repo.initializeTables()
-
-        const result = await repo.getUserById(99999)
-        assert.isUndefined(result)
-    })
-
-    test('getUserByKeycloakId() returns user with roles', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-        await repo.initializeTables()
-
-        await repo.findOrCreateUser({ id: 'keycloak-uuid-6', roles: ['editor'] })
-        const result = await repo.getUserByKeycloakId('keycloak-uuid-6')
-
-        assert.isDefined(result)
-        assert.equal(result!.keycloak_id, 'keycloak-uuid-6')
-        assert.includeMembers(result!.roles, ['editor'])
-    })
-
-    test('getUserByKeycloakId() returns undefined when not found', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-        await repo.initializeTables()
-
-        const result = await repo.getUserByKeycloakId('nonexistent')
-        assert.isUndefined(result)
-    })
-
-    test('keycloak_id uniqueness constraint', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-        await repo.initializeTables()
-
-        await db.insertInto('users').values({ keycloak_id: 'dup-id', created_at: new Date().toISOString(), updated_at: new Date().toISOString() }).execute()
-
-        await assert.rejects(
-            () => db.insertInto('users').values({ keycloak_id: 'dup-id', created_at: new Date().toISOString(), updated_at: new Date().toISOString() }).execute(),
-            /UNIQUE constraint failed/
-        )
-    })
-
-    test('timestamps are set on creation', async ({ assert }) => {
-        const repo = new KyselyUserRepository(db)
-        await repo.initializeTables()
-
-        const before = new Date()
-        const result = await repo.findOrCreateUser({ id: 'keycloak-uuid-7', roles: ['user'] })
-        const after = new Date()
-
-        assert.instanceOf(result.created_at, Date)
-        assert.instanceOf(result.updated_at, Date)
-        assert.isTrue(result.created_at! >= before)
-        assert.isTrue(result.updated_at! <= after)
-    })
-})
+if (process.env.TEST_PG_HOST) {
+    registerUserRepositoryTests('PostgreSQL', postgresKyselyFactory)
+}

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -23,8 +23,8 @@
     "dev": "tsc --watch",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "test": "node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix"
+    "lint": "eslint src tests --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint src tests --fix --no-error-on-unmatched-pattern"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/engine/tests/fixtures/mock_database.ts
+++ b/packages/engine/tests/fixtures/mock_database.ts
@@ -130,6 +130,8 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
 
     async createTableWithColumns(name: string, columns: Record<string, string>): Promise<void> {}
 
+    async ensureColumns(_tableName: string, _columns: Record<string, string>): Promise<void> {}
+
     async findByConditions(tableName: string, conditions: Record<string, any>): Promise<DataRecord[]> {
         return Array.from(this.records.values()).filter(r => {
             if (r.name !== tableName) return false
@@ -184,5 +186,4 @@ export class MockDatabaseAdapter extends DatabaseAdapter {
         }
     }
 
-    getKnex(): any { return {} }
 }

--- a/packages/ngsi-ld/bin/test.ts
+++ b/packages/ngsi-ld/bin/test.ts
@@ -14,7 +14,7 @@ configure({
         activated: ['spec'],
         list: [reporters.spec()],
     },
-    timeout: 10000,
+    timeout: 30000,
     forceExit: true,
     filters: {
         tests: process.env.TEST_NAME ? [process.env.TEST_NAME] : [],

--- a/packages/ngsi-ld/package.json
+++ b/packages/ngsi-ld/package.json
@@ -23,29 +23,32 @@
     "dev": "tsc --watch",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "test": "node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
-    "lint": "eslint src/**/*.ts"
+    "lint": "eslint src tests --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint src tests --fix --no-error-on-unmatched-pattern"
   },
   "engines": {
     "node": ">=20.0.0"
   },
   "dependencies": {
-    "@digitaltwin/shared": "workspace:*",
+    "@digitaltwin/components": "workspace:*",
     "@digitaltwin/database": "workspace:*",
-    "@digitaltwin/components": "workspace:*"
+    "@digitaltwin/shared": "workspace:*"
   },
   "peerDependencies": {
-    "ioredis": ">=5.0.0",
-    "bullmq": ">=5.0.0"
+    "bullmq": ">=5.0.0",
+    "ioredis": ">=5.0.0"
   },
   "devDependencies": {
     "@japa/assert": "^4.1.0",
     "@japa/runner": "^4.3.0",
+    "@testcontainers/postgresql": "^11.12.0",
     "@testcontainers/redis": "^11.3.1",
-    "testcontainers": "^11.3.1",
     "better-sqlite3": "^12.6.0",
     "bullmq": "^5.0.0",
     "ioredis": "^5.0.0",
+    "pg": "^8.20.0",
     "rimraf": "^6.0.1",
+    "testcontainers": "^11.3.1",
     "ts-node-maintained": "^10.9.5"
   },
   "repository": {

--- a/packages/ngsi-ld/tests/subscription_store.spec.ts
+++ b/packages/ngsi-ld/tests/subscription_store.spec.ts
@@ -5,11 +5,24 @@ import type { SubscriptionCreate } from '../src/types/subscription.js'
 
 const dataResolver = async (_url: string): Promise<Buffer> => Buffer.alloc(0)
 
-async function createDb(): Promise<KyselyDatabaseAdapter> {
-    return KyselyDatabaseAdapter.forSQLite(
-        { filename: ':memory:', enableForeignKeys: false },
-        dataResolver
-    )
+type StoreFactory = () => Promise<{ db: KyselyDatabaseAdapter; store: SubscriptionStore; cleanup: () => Promise<void> }>
+
+const sqliteFactory: StoreFactory = async () => {
+    const db = await KyselyDatabaseAdapter.forSQLite({ filename: ':memory:', enableForeignKeys: false }, dataResolver)
+    const store = new SubscriptionStore(db)
+    return { db, store, cleanup: () => db.close() }
+}
+
+const postgresFactory: StoreFactory = async () => {
+    const db = await KyselyDatabaseAdapter.forPostgreSQL({
+        host: process.env.TEST_PG_HOST!,
+        port: Number(process.env.TEST_PG_PORT),
+        user: process.env.TEST_PG_USER!,
+        password: process.env.TEST_PG_PASSWORD!,
+        database: process.env.TEST_PG_DATABASE!,
+    }, dataResolver)
+    const store = new SubscriptionStore(db)
+    return { db, store, cleanup: () => db.close() }
 }
 
 function makeInput(overrides: Partial<SubscriptionCreate> = {}): SubscriptionCreate {
@@ -23,293 +36,239 @@ function makeInput(overrides: Partial<SubscriptionCreate> = {}): SubscriptionCre
     }
 }
 
-test.group('SubscriptionStore — migration', group => {
-    let db: KyselyDatabaseAdapter
-    let store: SubscriptionStore
+function registerSubscriptionStoreTests(label: string, factory: StoreFactory) {
+    test.group(`SubscriptionStore [${label}] — migration`, group => {
+        let db: KyselyDatabaseAdapter
+        let store: SubscriptionStore
+        let cleanup: () => Promise<void>
 
-    group.each.setup(async () => {
-        db = await createDb()
-        store = new SubscriptionStore(db)
-    })
+        group.each.setup(async () => ({ db, store, cleanup } = await factory()))
+        group.each.teardown(async () => cleanup())
 
-    group.each.teardown(async () => {
-        await db.close()
-    })
-
-    test('runMigration() creates the table if absent', async ({ assert }) => {
-        await store.runMigration()
-        const exists = await db.doesTableExists('ngsi_ld_subscriptions')
-        assert.isTrue(exists)
-    })
-
-    test('runMigration() is idempotent', async ({ assert }) => {
-        await store.runMigration()
-        await assert.doesNotReject(() => store.runMigration())
-        const exists = await db.doesTableExists('ngsi_ld_subscriptions')
-        assert.isTrue(exists)
-    })
-
-    test('runMigration() adds missing columns to an existing table', async ({ assert }) => {
-        // Simulate a legacy table that pre-dates the times_failed column
-        await db.createTableWithColumns('ngsi_ld_subscriptions', {
-            sub_id: 'text not null',
-            notification_endpoint: 'text not null',
-            entity_types: 'text not null',
-            is_active: 'integer',
-            // times_failed intentionally absent — simulates old schema
+        test('runMigration() creates the table if absent', async ({ assert }) => {
+            await store.runMigration()
+            assert.isTrue(await db.doesTableExists('ngsi_ld_subscriptions'))
         })
 
-        // runMigration() should detect and add the missing columns
-        await store.runMigration()
-
-        // Verify the table still works end-to-end (times_failed is now present)
-        const sub = await store.create(makeInput())
-        await store.recordNotification(sub.id, false, new Date().toISOString())
-
-        const updated = await store.findById(sub.id)
-        assert.equal(updated!.timesFailed, 1)
-    })
-})
-
-test.group('SubscriptionStore — create', group => {
-    let db: KyselyDatabaseAdapter
-    let store: SubscriptionStore
-
-    group.each.setup(async () => {
-        db = await createDb()
-        store = new SubscriptionStore(db)
-        await store.runMigration()
-    })
-
-    group.each.teardown(async () => {
-        await db.close()
-    })
-
-    test('create() returns a subscription with a UUID id', async ({ assert }) => {
-        const sub = await store.create(makeInput())
-        assert.isString(sub.id)
-        // UUID format
-        assert.match(sub.id, /^[0-9a-f-]{36}$/)
-    })
-
-    test('entityTypes are correctly serialized and deserialized', async ({ assert }) => {
-        const sub = await store.create(makeInput({
-            entities: [{ type: 'WeatherObserved' }, { type: 'AirQualityObserved' }],
-        }))
-        assert.deepEqual(sub.entityTypes, ['WeatherObserved', 'AirQualityObserved'])
-    })
-
-    test('watchedAttributes null is preserved as undefined', async ({ assert }) => {
-        const sub = await store.create(makeInput({ watchedAttributes: undefined }))
-        assert.isUndefined(sub.watchedAttributes)
-    })
-
-    test('watchedAttributes array round-trips correctly', async ({ assert }) => {
-        const sub = await store.create(makeInput({ watchedAttributes: ['pm25', 'no2'] }))
-        assert.deepEqual(sub.watchedAttributes, ['pm25', 'no2'])
-    })
-
-    test('create() without entities defaults to empty entityTypes', async ({ assert }) => {
-        const sub = await store.create(makeInput({ entities: undefined }))
-        assert.deepEqual(sub.entityTypes, [])
-    })
-
-    test('create() sets isActive to true by default', async ({ assert }) => {
-        const sub = await store.create(makeInput())
-        assert.isTrue(sub.isActive)
-    })
-
-    test('create() initializes counters to zero', async ({ assert }) => {
-        const sub = await store.create(makeInput())
-        assert.equal(sub.timesSent, 0)
-        assert.equal(sub.timesFailed, 0)
-    })
-})
-
-test.group('SubscriptionStore — findAll', group => {
-    let db: KyselyDatabaseAdapter
-    let store: SubscriptionStore
-
-    group.each.setup(async () => {
-        db = await createDb()
-        store = new SubscriptionStore(db)
-        await store.runMigration()
-    })
-
-    group.each.teardown(async () => {
-        await db.close()
-    })
-
-    test('returns all active subscriptions', async ({ assert }) => {
-        await store.create(makeInput())
-        await store.create(makeInput())
-        const all = await store.findAll()
-        assert.lengthOf(all, 2)
-    })
-
-    test('does not return soft-deleted subscriptions', async ({ assert }) => {
-        const sub = await store.create(makeInput())
-        await store.delete(sub.id)
-
-        const all = await store.findAll()
-        assert.lengthOf(all, 0)
-    })
-})
-
-test.group('SubscriptionStore — findById', group => {
-    let db: KyselyDatabaseAdapter
-    let store: SubscriptionStore
-
-    group.each.setup(async () => {
-        db = await createDb()
-        store = new SubscriptionStore(db)
-        await store.runMigration()
-    })
-
-    group.each.teardown(async () => {
-        await db.close()
-    })
-
-    test('returns the subscription by UUID', async ({ assert }) => {
-        const created = await store.create(makeInput())
-        const found = await store.findById(created.id)
-        assert.isNotNull(found)
-        assert.equal(found!.id, created.id)
-    })
-
-    test('returns null for unknown id', async ({ assert }) => {
-        const found = await store.findById('00000000-0000-0000-0000-000000000000')
-        assert.isNull(found)
-    })
-})
-
-test.group('SubscriptionStore — update', group => {
-    let db: KyselyDatabaseAdapter
-    let store: SubscriptionStore
-
-    group.each.setup(async () => {
-        db = await createDb()
-        store = new SubscriptionStore(db)
-        await store.runMigration()
-    })
-
-    group.each.teardown(async () => {
-        await db.close()
-    })
-
-    test('updates the name field', async ({ assert }) => {
-        const sub = await store.create(makeInput({ name: 'original' }))
-        const updated = await store.update(sub.id, { name: 'updated' })
-        assert.equal(updated!.name, 'updated')
-    })
-
-    test('updates entityTypes with re-serialization', async ({ assert }) => {
-        const sub = await store.create(makeInput({ entities: [{ type: 'AirQualityObserved' }] }))
-        const updated = await store.update(sub.id, {
-            entities: [{ type: 'WeatherObserved' }],
+        test('runMigration() is idempotent', async ({ assert }) => {
+            await store.runMigration()
+            await assert.doesNotReject(() => store.runMigration())
+            assert.isTrue(await db.doesTableExists('ngsi_ld_subscriptions'))
         })
-        assert.deepEqual(updated!.entityTypes, ['WeatherObserved'])
+
+        test('runMigration() adds missing columns to an existing table', async ({ assert }) => {
+            await db.createTableWithColumns('ngsi_ld_subscriptions', {
+                sub_id: 'text not null',
+                notification_endpoint: 'text not null',
+                entity_types: 'text not null',
+                is_active: 'integer',
+                // times_failed intentionally absent — simulates old schema
+            })
+            await store.runMigration()
+            const sub = await store.create(makeInput())
+            await store.recordNotification(sub.id, false, new Date().toISOString())
+            const updated = await store.findById(sub.id)
+            assert.equal(updated!.timesFailed, 1)
+        })
     })
 
-    test('returns null for unknown id', async ({ assert }) => {
-        const result = await store.update('00000000-0000-0000-0000-000000000000', { name: 'x' })
-        assert.isNull(result)
-    })
-})
+    test.group(`SubscriptionStore [${label}] — create`, group => {
+        let store: SubscriptionStore
+        let cleanup: () => Promise<void>
 
-test.group('SubscriptionStore — delete', group => {
-    let db: KyselyDatabaseAdapter
-    let store: SubscriptionStore
+        group.each.setup(async () => {
+            ({ store, cleanup } = await factory())
+            await store.runMigration()
+        })
+        group.each.teardown(async () => cleanup())
 
-    group.each.setup(async () => {
-        db = await createDb()
-        store = new SubscriptionStore(db)
-        await store.runMigration()
-    })
+        test('create() returns a subscription with a UUID id', async ({ assert }) => {
+            const sub = await store.create(makeInput())
+            assert.isString(sub.id)
+            assert.match(sub.id, /^[0-9a-f-]{36}$/)
+        })
 
-    group.each.teardown(async () => {
-        await db.close()
-    })
+        test('entityTypes are correctly serialized and deserialized', async ({ assert }) => {
+            const sub = await store.create(makeInput({ entities: [{ type: 'WeatherObserved' }, { type: 'AirQualityObserved' }] }))
+            assert.deepEqual(sub.entityTypes, ['WeatherObserved', 'AirQualityObserved'])
+        })
 
-    test('soft-delete: findAll no longer returns the subscription', async ({ assert }) => {
-        const sub = await store.create(makeInput())
-        const deleted = await store.delete(sub.id)
-        assert.isTrue(deleted)
+        test('watchedAttributes null is preserved as undefined', async ({ assert }) => {
+            const sub = await store.create(makeInput({ watchedAttributes: undefined }))
+            assert.isUndefined(sub.watchedAttributes)
+        })
 
-        const all = await store.findAll()
-        const ids = all.map(s => s.id)
-        assert.notInclude(ids, sub.id)
-    })
+        test('watchedAttributes array round-trips correctly', async ({ assert }) => {
+            const sub = await store.create(makeInput({ watchedAttributes: ['pm25', 'no2'] }))
+            assert.deepEqual(sub.watchedAttributes, ['pm25', 'no2'])
+        })
 
-    test('soft-delete: findById returns null after delete', async ({ assert }) => {
-        const sub = await store.create(makeInput())
-        await store.delete(sub.id)
+        test('create() without entities defaults to empty entityTypes', async ({ assert }) => {
+            const sub = await store.create(makeInput({ entities: undefined }))
+            assert.deepEqual(sub.entityTypes, [])
+        })
 
-        const found = await store.findById(sub.id)
-        assert.isNull(found)
-    })
+        test('create() sets isActive to true by default', async ({ assert }) => {
+            const sub = await store.create(makeInput())
+            assert.isTrue(sub.isActive)
+        })
 
-    test('delete returns false for unknown id', async ({ assert }) => {
-        const result = await store.delete('00000000-0000-0000-0000-000000000000')
-        assert.isFalse(result)
-    })
-})
-
-test.group('SubscriptionStore — recordNotification', group => {
-    let db: KyselyDatabaseAdapter
-    let store: SubscriptionStore
-
-    group.each.setup(async () => {
-        db = await createDb()
-        store = new SubscriptionStore(db)
-        await store.runMigration()
+        test('create() initializes counters to zero', async ({ assert }) => {
+            const sub = await store.create(makeInput())
+            assert.equal(sub.timesSent, 0)
+            assert.equal(sub.timesFailed, 0)
+        })
     })
 
-    group.each.teardown(async () => {
-        await db.close()
+    test.group(`SubscriptionStore [${label}] — findAll`, group => {
+        let store: SubscriptionStore
+        let cleanup: () => Promise<void>
+
+        group.each.setup(async () => {
+            ({ store, cleanup } = await factory())
+            await store.runMigration()
+        })
+        group.each.teardown(async () => cleanup())
+
+        test('returns all active subscriptions', async ({ assert }) => {
+            await store.create(makeInput())
+            await store.create(makeInput())
+            assert.lengthOf(await store.findAll(), 2)
+        })
+
+        test('does not return soft-deleted subscriptions', async ({ assert }) => {
+            const sub = await store.create(makeInput())
+            await store.delete(sub.id)
+            assert.lengthOf(await store.findAll(), 0)
+        })
     })
 
-    test('success: increments timesSent and sets lastSuccessAt', async ({ assert }) => {
-        const sub = await store.create(makeInput())
-        const at = new Date().toISOString()
+    test.group(`SubscriptionStore [${label}] — findById`, group => {
+        let store: SubscriptionStore
+        let cleanup: () => Promise<void>
 
-        await store.recordNotification(sub.id, true, at)
+        group.each.setup(async () => {
+            ({ store, cleanup } = await factory())
+            await store.runMigration()
+        })
+        group.each.teardown(async () => cleanup())
 
-        const updated = await store.findById(sub.id)
-        assert.equal(updated!.timesSent, 1)
-        assert.equal(updated!.lastSuccessAt, at)
-        assert.equal(updated!.lastNotificationAt, at)
+        test('returns the subscription by UUID', async ({ assert }) => {
+            const created = await store.create(makeInput())
+            const found = await store.findById(created.id)
+            assert.isNotNull(found)
+            assert.equal(found!.id, created.id)
+        })
+
+        test('returns null for unknown id', async ({ assert }) => {
+            assert.isNull(await store.findById('00000000-0000-0000-0000-000000000000'))
+        })
     })
 
-    test('failure: increments timesSent and timesFailed, does not set lastSuccessAt', async ({ assert }) => {
-        const sub = await store.create(makeInput())
-        const at = new Date().toISOString()
+    test.group(`SubscriptionStore [${label}] — update`, group => {
+        let store: SubscriptionStore
+        let cleanup: () => Promise<void>
 
-        await store.recordNotification(sub.id, false, at)
+        group.each.setup(async () => {
+            ({ store, cleanup } = await factory())
+            await store.runMigration()
+        })
+        group.each.teardown(async () => cleanup())
 
-        const updated = await store.findById(sub.id)
-        assert.equal(updated!.timesSent, 1)
-        assert.equal(updated!.timesFailed, 1)
-        assert.isUndefined(updated!.lastSuccessAt)
-        assert.equal(updated!.lastNotificationAt, at)
+        test('updates the name field', async ({ assert }) => {
+            const sub = await store.create(makeInput({ name: 'original' }))
+            const updated = await store.update(sub.id, { name: 'updated' })
+            assert.equal(updated!.name, 'updated')
+        })
+
+        test('updates entityTypes with re-serialization', async ({ assert }) => {
+            const sub = await store.create(makeInput({ entities: [{ type: 'AirQualityObserved' }] }))
+            const updated = await store.update(sub.id, { entities: [{ type: 'WeatherObserved' }] })
+            assert.deepEqual(updated!.entityTypes, ['WeatherObserved'])
+        })
+
+        test('returns null for unknown id', async ({ assert }) => {
+            assert.isNull(await store.update('00000000-0000-0000-0000-000000000000', { name: 'x' }))
+        })
     })
 
-    test('multiple calls accumulate counters', async ({ assert }) => {
-        const sub = await store.create(makeInput())
-        const at = new Date().toISOString()
+    test.group(`SubscriptionStore [${label}] — delete`, group => {
+        let store: SubscriptionStore
+        let cleanup: () => Promise<void>
 
-        await store.recordNotification(sub.id, true, at)
-        await store.recordNotification(sub.id, false, at)
-        await store.recordNotification(sub.id, true, at)
+        group.each.setup(async () => {
+            ({ store, cleanup } = await factory())
+            await store.runMigration()
+        })
+        group.each.teardown(async () => cleanup())
 
-        const updated = await store.findById(sub.id)
-        assert.equal(updated!.timesSent, 3)
-        assert.equal(updated!.timesFailed, 1)
+        test('soft-delete: findAll no longer returns the subscription', async ({ assert }) => {
+            const sub = await store.create(makeInput())
+            assert.isTrue(await store.delete(sub.id))
+            const ids = (await store.findAll()).map(s => s.id)
+            assert.notInclude(ids, sub.id)
+        })
+
+        test('soft-delete: findById returns null after delete', async ({ assert }) => {
+            const sub = await store.create(makeInput())
+            await store.delete(sub.id)
+            assert.isNull(await store.findById(sub.id))
+        })
+
+        test('delete returns false for unknown id', async ({ assert }) => {
+            assert.isFalse(await store.delete('00000000-0000-0000-0000-000000000000'))
+        })
     })
 
-    test('is a no-op for unknown id', async ({ assert }) => {
-        await assert.doesNotReject(() =>
-            store.recordNotification('00000000-0000-0000-0000-000000000000', true, new Date().toISOString())
-        )
+    test.group(`SubscriptionStore [${label}] — recordNotification`, group => {
+        let store: SubscriptionStore
+        let cleanup: () => Promise<void>
+
+        group.each.setup(async () => {
+            ({ store, cleanup } = await factory())
+            await store.runMigration()
+        })
+        group.each.teardown(async () => cleanup())
+
+        test('success: increments timesSent and sets lastSuccessAt', async ({ assert }) => {
+            const sub = await store.create(makeInput())
+            const at = new Date().toISOString()
+            await store.recordNotification(sub.id, true, at)
+            const updated = await store.findById(sub.id)
+            assert.equal(updated!.timesSent, 1)
+            assert.equal(updated!.lastSuccessAt, at)
+        })
+
+        test('failure: increments timesFailed, does not set lastSuccessAt', async ({ assert }) => {
+            const sub = await store.create(makeInput())
+            await store.recordNotification(sub.id, false, new Date().toISOString())
+            const updated = await store.findById(sub.id)
+            assert.equal(updated!.timesSent, 1)
+            assert.equal(updated!.timesFailed, 1)
+            assert.isUndefined(updated!.lastSuccessAt)
+        })
+
+        test('multiple calls accumulate counters', async ({ assert }) => {
+            const sub = await store.create(makeInput())
+            const at = new Date().toISOString()
+            await store.recordNotification(sub.id, true, at)
+            await store.recordNotification(sub.id, false, at)
+            await store.recordNotification(sub.id, true, at)
+            const updated = await store.findById(sub.id)
+            assert.equal(updated!.timesSent, 3)
+            assert.equal(updated!.timesFailed, 1)
+        })
+
+        test('is a no-op for unknown id', async ({ assert }) => {
+            await assert.doesNotReject(() =>
+                store.recordNotification('00000000-0000-0000-0000-000000000000', true, new Date().toISOString())
+            )
+        })
     })
-})
+}
+
+registerSubscriptionStoreTests('SQLite', sqliteFactory)
+
+if (process.env.TEST_PG_HOST) {
+    registerSubscriptionStoreTests('PostgreSQL', postgresFactory)
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,8 +23,8 @@
     "dev": "tsc --watch",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "test": "node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix"
+    "lint": "eslint src tests --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint src tests --fix --no-error-on-unmatched-pattern"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -23,8 +23,8 @@
     "dev": "tsc --watch",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "test": "node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix"
+    "lint": "eslint src tests --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint src tests --fix --no-error-on-unmatched-pattern"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,12 +13,21 @@ importers:
 
   .:
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.39.2
+        version: 9.39.2
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
       '@types/node':
         specifier: ^24.1.0
         version: 24.10.8
+      eslint:
+        specifier: ^9.39.2
+        version: 9.39.2
+      globals:
+        specifier: ^15.15.0
+        version: 15.15.0
       rimraf:
         specifier: ^6.0.1
         version: 6.1.2
@@ -28,6 +37,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.53.0
+        version: 8.53.0(eslint@9.39.2)(typescript@5.9.3)
 
   create-digitaltwin:
     dependencies:
@@ -151,9 +163,6 @@ importers:
         specifier: ^2.0.9
         version: 2.0.15
     devDependencies:
-      '@eslint/js':
-        specifier: ^9.0.0
-        version: 9.39.2
       '@japa/assert':
         specifier: ^4.1.0
         version: 4.2.0(@japa/runner@4.5.0)
@@ -187,12 +196,6 @@ importers:
       c8:
         specifier: ^10.1.3
         version: 10.1.3
-      eslint:
-        specifier: ^9.0.0
-        version: 9.39.2
-      globals:
-        specifier: ^15.0.0
-        version: 15.15.0
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -205,9 +208,6 @@ importers:
       ts-node-maintained:
         specifier: ^10.9.5
         version: 10.9.6(@types/node@24.10.8)(typescript@5.9.3)
-      typescript-eslint:
-        specifier: ^8.0.0
-        version: 8.53.0(eslint@9.39.2)(typescript@5.9.3)
 
   packages/assets:
     dependencies:
@@ -294,7 +294,7 @@ importers:
         version: link:../shared
       knex:
         specifier: '>=3.0.0'
-        version: 3.1.0(better-sqlite3@12.6.0)(mysql2@3.16.0)(pg@8.16.3)(sqlite3@5.1.7)
+        version: 3.1.0(better-sqlite3@12.6.0)(pg@8.20.0)
     devDependencies:
       '@japa/assert':
         specifier: ^4.1.0
@@ -302,12 +302,21 @@ importers:
       '@japa/runner':
         specifier: ^4.3.0
         version: 4.5.0
+      '@testcontainers/postgresql':
+        specifier: ^11.12.0
+        version: 11.12.0
+      '@types/pg':
+        specifier: ^8.18.0
+        version: 8.18.0
       better-sqlite3:
         specifier: ^12.6.0
         version: 12.6.0
       kysely:
         specifier: ^0.28.11
         version: 0.28.11
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
       ts-node-maintained:
         specifier: ^10.9.5
         version: 10.9.6(@types/node@24.10.8)(typescript@5.9.3)
@@ -400,6 +409,9 @@ importers:
       '@japa/runner':
         specifier: ^4.3.0
         version: 4.5.0
+      '@testcontainers/postgresql':
+        specifier: ^11.12.0
+        version: 11.12.0
       '@testcontainers/redis':
         specifier: ^11.3.1
         version: 11.11.0
@@ -412,6 +424,9 @@ importers:
       ioredis:
         specifier: ^5.0.0
         version: 5.9.1
+      pg:
+        specifier: ^8.20.0
+        version: 8.20.0
       rimraf:
         specifier: ^6.0.1
         version: 6.1.2
@@ -1086,6 +1101,9 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
     cpu: [arm64]
@@ -1641,6 +1659,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@testcontainers/postgresql@11.12.0':
+    resolution: {integrity: sha512-w4ZK0H+WIYBUBk57H9wCSxPMSMZUNsFpx2MZAX4iru0Aevz9HFWDfAhFLAu+/SwsHtEJUD7XfWUDlqBGC3OF0Q==}
+
   '@testcontainers/redis@11.11.0':
     resolution: {integrity: sha512-IaDPNd1jRkshwJ69D7Nc3OTt5QQG1d4G1TZILSQ7gAVr4OqAJxoA9pV73ZvKIF/8LwxDDg136ApPlU9PcFtIKg==}
 
@@ -1686,6 +1707,9 @@ packages:
 
   '@types/dockerode@3.3.47':
     resolution: {integrity: sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==}
+
+  '@types/dockerode@4.0.1':
+    resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1737,6 +1761,9 @@ packages:
 
   '@types/node@24.10.8':
     resolution: {integrity: sha512-r0bBaXu5Swb05doFYO2kTWHMovJnNVbCsII0fhesM8bNRlLhXIuckley4a2DaD+vOdmm5G+zGkQZAPZsF80+YQ==}
+
+  '@types/pg@8.18.0':
+    resolution: {integrity: sha512-gT+oueVQkqnj6ajGJXblFR4iavIXWsGAFCk3dP4Kki5+a9R4NMt0JARdk6s8cUKcfUoqP5dAtDSLU8xYUTFV+Q==}
 
   '@types/pluralize@0.0.33':
     resolution: {integrity: sha512-JOqsl+ZoCpP4e8TDke9W79FDcSgPAR0l6pixx2JHkhnRjvShyYiAYw2LVsnA7K08Y6DeOnaU6ujmENO4os/cYg==}
@@ -2322,6 +2349,10 @@ packages:
 
   docker-compose@1.3.0:
     resolution: {integrity: sha512-7Gevk/5eGD50+eMD+XDnFnOrruFkL0kSd7jEG4cjmqweDSUhB7i0g8is/nBdVpl+Bx338SqIB2GLKm32M+Vs6g==}
+    engines: {node: '>= 6.0.0'}
+
+  docker-compose@1.3.1:
+    resolution: {integrity: sha512-rF0wH69G3CCcmkN9J1RVMQBaKe8o77LT/3XmqcLIltWWVxcWAzp2TnO7wS3n/umZHN3/EVrlT3exSBMal+Ou1w==}
     engines: {node: '>= 6.0.0'}
 
   docker-modem@5.0.6:
@@ -3100,6 +3131,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -3257,6 +3293,12 @@ packages:
   pg-cloudflare@1.2.7:
     resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
   pg-connection-string@2.6.2:
     resolution: {integrity: sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==}
 
@@ -3272,8 +3314,16 @@ packages:
     peerDependencies:
       pg: '>=8.0'
 
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
   pg-protocol@1.10.3:
     resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
@@ -3281,6 +3331,15 @@ packages:
 
   pg@8.16.3:
     resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       pg-native: '>=3.0.1'
@@ -3377,6 +3436,10 @@ packages:
   properties-reader@2.3.0:
     resolution: {integrity: sha512-z597WicA7nDZxK12kZqHr2TcvwNU1GCfA5UwfDY/HDp3hXPoPlb5rlEx9bwGTiJnc0OqbBTkU975jDToth8Gxw==}
     engines: {node: '>=14'}
+
+  properties-reader@3.0.1:
+    resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
+    engines: {node: '>=18'}
 
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
@@ -3722,6 +3785,9 @@ packages:
   testcontainers@11.11.0:
     resolution: {integrity: sha512-nKTJn3n/gkyGg/3SVkOwX+isPOGSHlfI+CWMobSmvQrsj7YW01aWvl2pYIfV4LMd+C8or783yYrzKSK2JlP+Qw==}
 
+  testcontainers@11.12.0:
+    resolution: {integrity: sha512-VWtH+UQejVYYvb53ohEZRbx2naxyDvwO9lQ6A0VgmVE2Oh8r9EF09I+BfmrXpd9N9ntpzhao9di2yNwibSz5KA==}
+
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
@@ -3829,6 +3895,10 @@ packages:
 
   undici@7.18.2:
     resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
     engines: {node: '>=20.18.1'}
 
   unique-filename@1.1.1:
@@ -5122,6 +5192,12 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -5923,6 +5999,15 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@testcontainers/postgresql@11.12.0':
+    dependencies:
+      testcontainers: 11.12.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   '@testcontainers/redis@11.11.0':
     dependencies:
       testcontainers: 11.11.0
@@ -5978,6 +6063,12 @@ snapshots:
       '@types/ssh2': 1.15.5
 
   '@types/dockerode@3.3.47':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 24.10.8
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
       '@types/node': 24.10.8
@@ -6049,6 +6140,12 @@ snapshots:
   '@types/node@24.10.8':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/pg@8.18.0':
+    dependencies:
+      '@types/node': 24.10.8
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
 
   '@types/pluralize@0.0.33': {}
 
@@ -6679,6 +6776,10 @@ snapshots:
     dependencies:
       yaml: 2.8.2
 
+  docker-compose@1.3.1:
+    dependencies:
+      yaml: 2.8.2
+
   docker-modem@5.0.6:
     dependencies:
       debug: 4.4.3
@@ -7306,6 +7407,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  knex@3.1.0(better-sqlite3@12.6.0)(pg@8.20.0):
+    dependencies:
+      colorette: 2.0.19
+      commander: 10.0.1
+      debug: 4.3.4
+      escalade: 3.2.0
+      esm: 3.2.25
+      get-package-type: 0.1.0
+      getopts: 2.3.0
+      interpret: 2.2.0
+      lodash: 4.17.23
+      pg-connection-string: 2.6.2
+      rechoir: 0.8.0
+      resolve-from: 5.0.0
+      tarn: 3.0.2
+      tildify: 2.0.0
+    optionalDependencies:
+      better-sqlite3: 12.6.0
+      pg: 8.20.0
+    transitivePeerDependencies:
+      - supports-color
+
   kysely@0.28.11: {}
 
   lazystream@1.0.1:
@@ -7502,6 +7625,8 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
+  mkdirp@3.0.1: {}
+
   ms@2.0.0: {}
 
   ms@2.1.2: {}
@@ -7676,6 +7801,11 @@ snapshots:
   pg-cloudflare@1.2.7:
     optional: true
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
   pg-connection-string@2.6.2: {}
 
   pg-connection-string@2.9.1: {}
@@ -7686,7 +7816,13 @@ snapshots:
     dependencies:
       pg: 8.16.3
 
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
   pg-protocol@1.10.3: {}
+
+  pg-protocol@1.13.0: {}
 
   pg-types@2.2.0:
     dependencies:
@@ -7705,6 +7841,16 @@ snapshots:
       pgpass: 1.0.5
     optionalDependencies:
       pg-cloudflare: 1.2.7
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
 
   pgpass@1.0.5:
     dependencies:
@@ -7786,6 +7932,13 @@ snapshots:
   properties-reader@2.3.0:
     dependencies:
       mkdirp: 1.0.4
+
+  properties-reader@3.0.1:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      mkdirp: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   protobufjs@7.5.4:
     dependencies:
@@ -8219,6 +8372,29 @@ snapshots:
       - react-native-b4a
       - supports-color
 
+  testcontainers@11.12.0:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@types/dockerode': 4.0.1
+      archiver: 7.0.1
+      async-lock: 1.4.1
+      byline: 5.0.0
+      debug: 4.4.3
+      docker-compose: 1.3.1
+      dockerode: 4.0.9
+      get-port: 7.1.0
+      proper-lockfile: 4.1.2
+      properties-reader: 3.0.1
+      ssh-remote-port-forward: 1.0.4
+      tar-fs: 3.1.1
+      tmp: 0.2.5
+      undici: 7.22.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   text-decoder@1.2.3:
     dependencies:
       b4a: 1.7.3
@@ -8344,6 +8520,8 @@ snapshots:
       '@fastify/busboy': 2.1.1
 
   undici@7.18.2: {}
+
+  undici@7.22.0: {}
 
   unique-filename@1.1.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Move ESLint config to workspace root so all packages are linted in CI
- Add PostgreSQL service container to CI workflow
- Add PG integration tests for `@digitaltwin/database` and `@digitaltwin/ngsi-ld` (conditional on `TEST_PG_HOST`)
- Fix `KyselyUserRepository.initializeTables()` to use `serial` type for PostgreSQL instead of `AUTO_INCREMENT` (MySQL-only syntax)

## Test plan
- [ ] CI lint passes for all packages
- [ ] SQLite tests pass (always)
- [ ] PostgreSQL tests pass (via CI service container)
- [ ] Both Node 20 and Node 22 matrix pass