### PR TITLE
Add E2E test suite with HTTP integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,20 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      minio:
+        image: bitnami/minio
+        env:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+          MINIO_DEFAULT_BUCKETS: test-bucket
+        ports:
+          - 9000:9000
+        options: >-
+          --health-cmd "curl -f http://localhost:9000/minio/health/live || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,3 +81,21 @@ jobs:
           TEST_PG_USER: test
           TEST_PG_PASSWORD: test
           TEST_PG_DATABASE: test
+          TEST_MINIO_ENDPOINT: http://localhost:9000
+          TEST_MINIO_ACCESS_KEY: minioadmin
+          TEST_MINIO_SECRET_KEY: minioadmin
+          TEST_MINIO_BUCKET: test-bucket
+
+      - name: E2E Tests
+        run: pnpm test:e2e
+        env:
+          NODE_ENV: test
+          TEST_PG_HOST: localhost
+          TEST_PG_PORT: 5432
+          TEST_PG_USER: test
+          TEST_PG_PASSWORD: test
+          TEST_PG_DATABASE: test
+          TEST_MINIO_ENDPOINT: http://localhost:9000
+          TEST_MINIO_ACCESS_KEY: minioadmin
+          TEST_MINIO_SECRET_KEY: minioadmin
+          TEST_MINIO_BUCKET: test-bucket

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,10 @@ jobs:
           --health-retries 5
 
       minio:
-        image: bitnami/minio:2025
+        image: fclairamb/minio-github-actions
         env:
           MINIO_ROOT_USER: minioadmin
           MINIO_ROOT_PASSWORD: minioadmin
-          MINIO_DEFAULT_BUCKETS: test-bucket
         ports:
           - 9000:9000
         options: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           --health-retries 5
 
       minio:
-        image: bitnami/minio
+        image: bitnami/minio:2025
         env:
           MINIO_ROOT_USER: minioadmin
           MINIO_ROOT_PASSWORD: minioadmin

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:create": "pnpm --filter create-digitaltwin run build",
     "clean": "pnpm -r run clean",
     "test": "pnpm --filter @digitaltwin/shared run test && pnpm --filter @digitaltwin/database run test && pnpm --filter @digitaltwin/storage run test && pnpm --filter @digitaltwin/auth run test && pnpm --filter @digitaltwin/assets run test && pnpm --filter @digitaltwin/ngsi-ld run test && pnpm --filter @digitaltwin/engine run test && pnpm --filter digitaltwin-core run test",
+    "test:e2e": "pnpm --filter @digitaltwin/e2e test",
     "test:shared": "pnpm --filter @digitaltwin/shared run test",
     "lint": "pnpm -r run lint",
     "lint:fix": "pnpm -r run lint:fix",

--- a/packages/e2e/bin/set-test-env.cjs
+++ b/packages/e2e/bin/set-test-env.cjs
@@ -1,0 +1,4 @@
+// CommonJS preload script to set environment variables before ESM loader
+process.env.NODE_ENV = 'test'
+process.env.TS_NODE_PROJECT = 'tsconfig.test.json'
+process.env.TS_NODE_TRANSPILE_ONLY = 'true'

--- a/packages/e2e/bin/test.ts
+++ b/packages/e2e/bin/test.ts
@@ -1,0 +1,29 @@
+import { configure, run } from '@japa/runner'
+import { assert } from '@japa/assert'
+import * as reporters from '@japa/runner/reporters'
+
+// Set test environment
+process.env.NODE_ENV = 'test'
+
+// Get file filter from CLI args
+const args = process.argv.slice(2).filter(arg => arg !== '--')
+const fileFilter = args.length > 0 ? args : []
+
+configure({
+    files: ['tests/**/*.spec.ts'],
+    plugins: [assert()],
+    reporters: {
+        activated: ['spec'],
+        list: [
+            reporters.spec(),
+        ],
+    },
+    timeout: 60000,
+    forceExit: true,
+    filters: {
+        tests: process.env.TEST_NAME ? [process.env.TEST_NAME] : [],
+        files: fileFilter,
+    },
+})
+
+run()

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@digitaltwin/e2e",
+  "version": "1.0.0",
+  "private": true,
+  "description": "End-to-end integration tests for Digital Twin framework",
+  "license": "MIT",
+  "author": "Axel Hoffmann",
+  "type": "module",
+  "scripts": {
+    "test": "node -r ./bin/set-test-env.cjs --import ts-node-maintained/register/esm --enable-source-maps bin/test.ts",
+    "lint": "eslint tests --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint tests --fix --no-error-on-unmatched-pattern"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "dependencies": {
+    "@digitaltwin/shared": "workspace:*",
+    "@digitaltwin/database": "workspace:*",
+    "@digitaltwin/storage": "workspace:*",
+    "@digitaltwin/auth": "workspace:*",
+    "@digitaltwin/components": "workspace:*",
+    "@digitaltwin/assets": "workspace:*",
+    "@digitaltwin/engine": "workspace:*"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-s3": "^3.1002.0",
+    "@aws-sdk/s3-request-presigner": "^3.1002.0",
+    "@japa/assert": "^4.1.0",
+    "@japa/runner": "^4.3.0",
+    "@testcontainers/redis": "^11.3.1",
+    "jszip": "^3.10.1",
+    "pg": "^8.16.0",
+    "testcontainers": "^10.0.0",
+    "ts-node-maintained": "^10.9.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CePseudoBE/digitaltwin.git",
+    "directory": "packages/e2e"
+  }
+}

--- a/packages/e2e/tests/assets_presigned.spec.ts
+++ b/packages/e2e/tests/assets_presigned.spec.ts
@@ -1,0 +1,177 @@
+import { test } from '@japa/runner'
+import { setupInfrastructure, type E2EInfrastructure } from './helpers/setup.js'
+import { makeAuthRequest } from './helpers/auth_helpers.js'
+import { E2EAssetsManager } from './helpers/test_components.js'
+import { AuthConfig } from '@digitaltwin/auth'
+import type { TypedRequest } from '@digitaltwin/shared'
+
+/** Helper to build a valid presigned upload request body (includes required fileSize) */
+function presignedBody(overrides: Record<string, unknown> = {}) {
+    return {
+        fileName: 'test-file.bin',
+        fileSize: 1024,
+        contentType: 'application/octet-stream',
+        description: 'E2E test file',
+        source: 'https://example.com',
+        ...overrides,
+    }
+}
+
+test.group('AssetsManager presigned upload E2E', (group) => {
+    let infra: E2EInfrastructure
+    let manager: E2EAssetsManager
+
+    group.setup(async () => {
+        infra = await setupInfrastructure()
+        manager = new E2EAssetsManager()
+        manager.setDependencies(infra.db, infra.storage, infra.authMiddleware)
+
+        // Create the assets table with extended columns
+        const config = manager.getConfiguration()
+        await infra.db.createTable(config.name)
+        await infra.db.ensureColumns(config.name, {
+            description: 'text',
+            source: 'text',
+            owner_id: 'integer',
+            filename: 'text',
+            is_public: 'boolean default true',
+            upload_status: 'text',
+            upload_error: 'text',
+            upload_job_id: 'text',
+            presigned_key: 'text',
+            presigned_expires_at: 'timestamp',
+            created_at: 'timestamp',
+            updated_at: 'timestamp',
+        })
+    })
+
+    group.teardown(async () => {
+        // Ensure auth is disabled again for cleanup
+        process.env.DIGITALTWIN_DISABLE_AUTH = 'true'
+        AuthConfig._resetConfig()
+        await infra.cleanup()
+    })
+
+    test('handleUploadRequest returns presigned URL with pending status in DB', async ({ assert }) => {
+        const req = await makeAuthRequest(infra.db, 'user-presigned-1', ['user'], {
+            body: presignedBody(),
+        })
+
+        const response = await (manager as any).presignedService.handleUploadRequest(req as unknown as TypedRequest)
+        assert.equal(response.status, 200)
+
+        const parsed = JSON.parse(response.content as string)
+        assert.properties(parsed, ['fileId', 'uploadUrl', 'key', 'expiresAt'])
+        assert.isAbove(parsed.fileId, 0)
+        assert.isString(parsed.uploadUrl)
+        assert.include(parsed.uploadUrl, 'X-Amz-Signature')
+    })
+
+    test('PUT to presigned URL + handleConfirm marks upload completed', async ({ assert }) => {
+        const req = await makeAuthRequest(infra.db, 'user-presigned-2', ['user'], {
+            body: presignedBody({ fileName: 'confirm-test.bin' }),
+        })
+
+        const uploadResponse = await (manager as any).presignedService.handleUploadRequest(req as unknown as TypedRequest)
+        assert.equal(uploadResponse.status, 200)
+        const { fileId, uploadUrl, key } = JSON.parse(uploadResponse.content as string)
+
+        // PUT file directly to MinIO via the presigned URL
+        const putResponse = await fetch(uploadUrl, {
+            method: 'PUT',
+            body: Buffer.from('hello-e2e-presigned-upload'),
+            headers: { 'Content-Type': 'application/octet-stream' },
+        })
+        assert.equal(putResponse.status, 200)
+
+        // Confirm
+        const confirmReq = await makeAuthRequest(infra.db, 'user-presigned-2', ['user'], {
+            params: { fileId: String(fileId) },
+        })
+        const confirmResponse = await (manager as any).presignedService.handleConfirm(confirmReq as unknown as TypedRequest)
+        assert.equal(confirmResponse.status, 200)
+
+        const parsed = JSON.parse(confirmResponse.content as string)
+        assert.equal(parsed.id, fileId)
+        assert.equal(parsed.url, key)
+    })
+
+    test('handleConfirm without actual upload fails', async ({ assert }) => {
+        const req = await makeAuthRequest(infra.db, 'user-presigned-3', ['user'], {
+            body: presignedBody({ fileName: 'no-upload.bin' }),
+        })
+
+        const uploadResponse = await (manager as any).presignedService.handleUploadRequest(req as unknown as TypedRequest)
+        const { fileId } = JSON.parse(uploadResponse.content as string)
+
+        const confirmReq = await makeAuthRequest(infra.db, 'user-presigned-3', ['user'], {
+            params: { fileId: String(fileId) },
+        })
+        const confirmResponse = await (manager as any).presignedService.handleConfirm(confirmReq as unknown as TypedRequest)
+        assert.equal(confirmResponse.status, 400)
+    })
+
+    test('wrong owner gets 403 on confirm', async ({ assert }) => {
+        // User A requests upload (with auth disabled, gets anonymous user)
+        const reqA = await makeAuthRequest(infra.db, 'user-owner-a', ['user'], {
+            body: presignedBody({ fileName: 'owner-test.bin' }),
+        })
+
+        const uploadResponse = await (manager as any).presignedService.handleUploadRequest(reqA as unknown as TypedRequest)
+        const { fileId, uploadUrl } = JSON.parse(uploadResponse.content as string)
+
+        // Upload the file
+        await fetch(uploadUrl, {
+            method: 'PUT',
+            body: Buffer.from('owner-test-content'),
+            headers: { 'Content-Type': 'application/octet-stream' },
+        })
+
+        // Re-enable auth and reset cache so AuthMiddleware checks headers
+        delete process.env.DIGITALTWIN_DISABLE_AUTH
+        AuthConfig._resetConfig()
+
+        // User B (different keycloak ID) tries to confirm — should fail
+        const reqB = await makeAuthRequest(infra.db, 'user-owner-b', ['user'], {
+            params: { fileId: String(fileId) },
+        })
+
+        const confirmResponse = await (manager as any).presignedService.handleConfirm(reqB as unknown as TypedRequest)
+        // 401 because APISIX header validation fails (no real gateway), or 403 if it passes
+        assert.oneOf(confirmResponse.status, [401, 403])
+
+        // Restore disabled auth
+        process.env.DIGITALTWIN_DISABLE_AUTH = 'true'
+        AuthConfig._resetConfig()
+    })
+
+    test('double confirm returns 409', async ({ assert }) => {
+        const req = await makeAuthRequest(infra.db, 'user-double-confirm', ['user'], {
+            body: presignedBody({ fileName: 'double-confirm.bin' }),
+        })
+
+        const uploadResponse = await (manager as any).presignedService.handleUploadRequest(req as unknown as TypedRequest)
+        const { fileId, uploadUrl } = JSON.parse(uploadResponse.content as string)
+
+        // Upload file
+        await fetch(uploadUrl, {
+            method: 'PUT',
+            body: Buffer.from('double-confirm-content'),
+            headers: { 'Content-Type': 'application/octet-stream' },
+        })
+
+        // First confirm succeeds
+        const confirmReq1 = await makeAuthRequest(infra.db, 'user-double-confirm', ['user'], {
+            params: { fileId: String(fileId) },
+        })
+        const response1 = await (manager as any).presignedService.handleConfirm(confirmReq1 as unknown as TypedRequest)
+        assert.equal(response1.status, 200)
+
+        // Second confirm returns 409
+        const confirmReq2 = await makeAuthRequest(infra.db, 'user-double-confirm', ['user'], {
+            params: { fileId: String(fileId) },
+        })
+        const response2 = await (manager as any).presignedService.handleConfirm(confirmReq2 as unknown as TypedRequest)
+        assert.equal(response2.status, 409)
+    })
+})

--- a/packages/e2e/tests/collector.spec.ts
+++ b/packages/e2e/tests/collector.spec.ts
@@ -1,0 +1,73 @@
+import { test } from '@japa/runner'
+import { setupInfrastructure, type E2EInfrastructure } from './helpers/setup.js'
+import { WeatherCollector } from './helpers/test_components.js'
+
+test.group('Collector E2E', (group) => {
+    let infra: E2EInfrastructure
+    let collector: WeatherCollector
+
+    group.setup(async () => {
+        infra = await setupInfrastructure()
+        collector = new WeatherCollector()
+        collector.setDependencies(infra.db, infra.storage)
+
+        // Create the collector's table
+        const config = collector.getConfiguration()
+        await infra.db.createTable(config.name)
+    })
+
+    group.teardown(async () => {
+        await infra.cleanup()
+    })
+
+    test('run() persists data to PostgreSQL and MinIO', async ({ assert }) => {
+        const result = await collector.run()
+        assert.instanceOf(result, Buffer)
+
+        const parsed = JSON.parse(result!.toString())
+        assert.properties(parsed, ['temperature', 'humidity', 'pressure', 'timestamp'])
+    })
+
+    test('retrieve() returns latest collected data', async ({ assert }) => {
+        // Ensure at least one run has happened
+        await collector.run()
+
+        const response = await collector.retrieve()
+        assert.equal(response.status, 200)
+        assert.instanceOf(response.content, Buffer)
+
+        const parsed = JSON.parse(response.content.toString())
+        assert.equal(parsed.temperature, 22.5)
+    })
+
+    test('multiple runs create multiple records in the database', async ({ assert }) => {
+        // Run collector 3 times
+        await collector.run()
+        await collector.run()
+        await collector.run()
+
+        const config = collector.getConfiguration()
+
+        // Verify we can get the latest
+        const latest = await infra.db.getLatestByName(config.name)
+        assert.isDefined(latest)
+
+        // Verify we can get records by date range (all records)
+        const all = await infra.db.getByDateRange(config.name, new Date('2000-01-01'))
+        assert.isAbove(all.length, 1)
+    })
+
+    test('retrieve() returns 404 for empty collector', async ({ assert }) => {
+        // Create a new collector with a different name, no runs
+        const emptyCollector = new (class extends WeatherCollector {
+            override getConfiguration() {
+                return { ...super.getConfiguration(), name: 'e2e_empty_collector', endpoint: 'e2e-empty' }
+            }
+        })()
+        emptyCollector.setDependencies(infra.db, infra.storage)
+        await infra.db.createTable('e2e_empty_collector')
+
+        const response = await emptyCollector.retrieve()
+        assert.equal(response.status, 404)
+    })
+})

--- a/packages/e2e/tests/custom_table_manager.spec.ts
+++ b/packages/e2e/tests/custom_table_manager.spec.ts
@@ -1,0 +1,175 @@
+import { test } from '@japa/runner'
+import { setupInfrastructure, type E2EInfrastructure } from './helpers/setup.js'
+import { makeAuthRequest } from './helpers/auth_helpers.js'
+import { E2ECustomTableManager } from './helpers/test_components.js'
+import { AuthConfig } from '@digitaltwin/auth'
+
+test.group('CustomTableManager E2E', (group) => {
+    let infra: E2EInfrastructure
+    let manager: E2ECustomTableManager
+
+    group.setup(async () => {
+        infra = await setupInfrastructure()
+        manager = new E2ECustomTableManager()
+        manager.setDependencies(infra.db, infra.authMiddleware)
+        await manager.initializeTable()
+    })
+
+    group.teardown(async () => {
+        process.env.DIGITALTWIN_DISABLE_AUTH = 'true'
+        AuthConfig._resetConfig()
+        await infra.cleanup()
+    })
+
+    test('handleCreate sets owner_id from authenticated user', async ({ assert }) => {
+        const req = await makeAuthRequest(infra.db, 'user-ctm-1', ['user'], {
+            body: { title: 'Test Record', value: 42, active: true },
+        })
+
+        const response = await manager.handleCreate(req)
+        assert.equal(response.status, 201)
+
+        const parsed = JSON.parse(response.content as string)
+        assert.property(parsed, 'id')
+        assert.isAbove(parsed.id, 0)
+
+        // Verify owner_id was set
+        const record = await manager.findById(parsed.id)
+        assert.isDefined(record)
+        assert.isDefined(record!.owner_id)
+    })
+
+    test('handleGetAll returns all records', async ({ assert }) => {
+        const response = await manager.handleGetAll({})
+        assert.equal(response.status, 200)
+
+        const records = JSON.parse(response.content as string)
+        assert.isArray(records)
+        assert.isAbove(records.length, 0)
+    })
+
+    test('handleGetById returns specific record', async ({ assert }) => {
+        const createReq = await makeAuthRequest(infra.db, 'user-ctm-2', ['user'], {
+            body: { title: 'Specific Record', value: 100 },
+        })
+        const createResp = await manager.handleCreate(createReq)
+        const { id } = JSON.parse(createResp.content as string)
+
+        const response = await manager.handleGetById({ params: { id: String(id) } })
+        assert.equal(response.status, 200)
+
+        const record = JSON.parse(response.content as string)
+        assert.equal(record.title, 'Specific Record')
+        assert.equal(record.value, 100)
+    })
+
+    test('handleUpdate allows owner to update', async ({ assert }) => {
+        const createReq = await makeAuthRequest(infra.db, 'user-ctm-3', ['user'], {
+            body: { title: 'Updatable Record', value: 10 },
+        })
+        const createResp = await manager.handleCreate(createReq)
+        const { id } = JSON.parse(createResp.content as string)
+
+        // Update as same user (anonymous, same owner_id)
+        const updateReq = await makeAuthRequest(infra.db, 'user-ctm-3', ['user'], {
+            params: { id: String(id) },
+            body: { title: 'Updated Record', value: 20 },
+        })
+        const updateResp = await manager.handleUpdate(updateReq)
+        assert.equal(updateResp.status, 200)
+
+        const record = await manager.findById(id)
+        assert.equal(record!.title, 'Updated Record')
+        assert.equal(record!.value, 20)
+    })
+
+    test('handleUpdate returns 403 for non-owner', async ({ assert }) => {
+        // Create a record — with auth disabled, it gets the anonymous user's owner_id
+        const createReq = await makeAuthRequest(infra.db, 'user-ctm-4', ['user'], {
+            body: { title: 'Owned Record', value: 50 },
+        })
+        const createResp = await manager.handleCreate(createReq)
+        const { id } = JSON.parse(createResp.content as string)
+
+        // Manually change owner_id to a different user to simulate different ownership
+        const otherUser = await infra.db.getUserRepository().findOrCreateUser({ id: 'user-ctm-other-owner', roles: ['user'] })
+        await infra.db.updateById('e2e_custom_records', id, { owner_id: otherUser.id })
+
+        // Now try to update — the anonymous user (from auth disabled) has a different ID
+        const updateReq = await makeAuthRequest(infra.db, 'user-ctm-5', ['user'], {
+            params: { id: String(id) },
+            body: { title: 'Hacked Record' },
+        })
+        const updateResp = await manager.handleUpdate(updateReq)
+        assert.equal(updateResp.status, 403)
+    })
+
+    test('handleDelete allows owner to delete', async ({ assert }) => {
+        const createReq = await makeAuthRequest(infra.db, 'user-ctm-6', ['user'], {
+            body: { title: 'Deletable Record', value: 999 },
+        })
+        const createResp = await manager.handleCreate(createReq)
+        const { id } = JSON.parse(createResp.content as string)
+
+        const deleteReq = await makeAuthRequest(infra.db, 'user-ctm-6', ['user'], {
+            params: { id: String(id) },
+        })
+        const deleteResp = await manager.handleDelete(deleteReq)
+        assert.equal(deleteResp.status, 200)
+
+        const record = await manager.findById(id)
+        assert.isNull(record)
+    })
+
+    test('handleDelete returns 403 for non-owner', async ({ assert }) => {
+        const createReq = await makeAuthRequest(infra.db, 'user-ctm-7', ['user'], {
+            body: { title: 'Protected Record', value: 777 },
+        })
+        const createResp = await manager.handleCreate(createReq)
+        const { id } = JSON.parse(createResp.content as string)
+
+        // Change owner to a different user
+        const otherUser = await infra.db.getUserRepository().findOrCreateUser({ id: 'user-ctm-other-owner-2', roles: ['user'] })
+        await infra.db.updateById('e2e_custom_records', id, { owner_id: otherUser.id })
+
+        // Try to delete — should fail because anonymous user doesn't own it
+        const deleteReq = await makeAuthRequest(infra.db, 'user-ctm-8', ['user'], {
+            params: { id: String(id) },
+        })
+        const deleteResp = await manager.handleDelete(deleteReq)
+        assert.equal(deleteResp.status, 403)
+
+        const record = await manager.findById(id)
+        assert.isDefined(record)
+    })
+
+    test('handleGetById returns 404 for non-existent record', async ({ assert }) => {
+        const response = await manager.handleGetById({ params: { id: '99999' } })
+        assert.equal(response.status, 404)
+    })
+
+    test('handleCreate returns 401 without auth', async ({ assert }) => {
+        // Enable auth and reset ALL cached configs (AuthConfig + ApisixAuthParser provider)
+        delete process.env.DIGITALTWIN_DISABLE_AUTH
+        AuthConfig._resetConfig()
+        const { ApisixAuthParser, UserService, AuthMiddleware: AM } = await import('@digitaltwin/auth')
+        ApisixAuthParser._resetProvider()
+
+        // Create a fresh AuthMiddleware so it picks up the new config
+        const freshAuth = new AM(new UserService(infra.db.getUserRepository()))
+        const freshManager = new E2ECustomTableManager()
+        freshManager.setDependencies(infra.db, freshAuth)
+        await freshManager.initializeTable()
+
+        const response = await freshManager.handleCreate({
+            headers: {},
+            body: { title: 'No Auth', value: 0 },
+        })
+        assert.equal(response.status, 401)
+
+        // Restore disabled auth
+        process.env.DIGITALTWIN_DISABLE_AUTH = 'true'
+        AuthConfig._resetConfig()
+        ApisixAuthParser._resetProvider()
+    })
+})

--- a/packages/e2e/tests/handler.spec.ts
+++ b/packages/e2e/tests/handler.spec.ts
@@ -1,0 +1,45 @@
+import { test } from '@japa/runner'
+import { CalculatorHandler } from './helpers/test_components.js'
+import type { TypedRequest } from '@digitaltwin/shared'
+
+test.group('Handler E2E', () => {
+    const handler = new CalculatorHandler()
+
+    test('exposes declared endpoints', ({ assert }) => {
+        const endpoints = handler.getEndpoints()
+        assert.isAbove(endpoints.length, 0)
+
+        const paths = endpoints.map(e => e.path)
+        assert.include(paths, '/e2e-calculator/sum')
+        assert.include(paths, '/e2e-calculator/health')
+    })
+
+    test('calculateSum returns computed response', async ({ assert }) => {
+        const fakeReq = {
+            body: { a: 10, b: 32 },
+            headers: {},
+            params: {},
+            query: {},
+        } as unknown as TypedRequest
+
+        const endpoints = handler.getEndpoints()
+        const sumEndpoint = endpoints.find(e => e.path === '/e2e-calculator/sum')!
+
+        const response = await sumEndpoint.handler(fakeReq)
+        assert.equal(response.status, 200)
+
+        const parsed = JSON.parse(response.content as string)
+        assert.equal(parsed.result, 42)
+    })
+
+    test('healthCheck is stateless', async ({ assert }) => {
+        const endpoints = handler.getEndpoints()
+        const healthEndpoint = endpoints.find(e => e.path === '/e2e-calculator/health')!
+
+        const response = await healthEndpoint.handler()
+        assert.equal(response.status, 200)
+
+        const parsed = JSON.parse(response.content as string)
+        assert.equal(parsed.status, 'ok')
+    })
+})

--- a/packages/e2e/tests/harvester.spec.ts
+++ b/packages/e2e/tests/harvester.spec.ts
@@ -1,0 +1,68 @@
+import { test } from '@japa/runner'
+import { setupInfrastructure, type E2EInfrastructure } from './helpers/setup.js'
+import { WeatherCollector, WeatherAverageHarvester } from './helpers/test_components.js'
+
+test.group('Harvester E2E', (group) => {
+    let infra: E2EInfrastructure
+    let collector: WeatherCollector
+    let harvester: WeatherAverageHarvester
+
+    group.setup(async () => {
+        infra = await setupInfrastructure()
+
+        collector = new WeatherCollector()
+        collector.setDependencies(infra.db, infra.storage)
+
+        harvester = new WeatherAverageHarvester()
+        harvester.setDependencies(infra.db, infra.storage)
+
+        // Create tables
+        await infra.db.createTable(collector.getConfiguration().name)
+        await infra.db.createTable(harvester.getConfiguration().name)
+    })
+
+    group.teardown(async () => {
+        await infra.cleanup()
+    })
+
+    test('run() returns false when no source data exists', async ({ assert }) => {
+        const result = await harvester.run()
+        assert.isFalse(result)
+    })
+
+    test('run() processes source data from collector', async ({ assert }) => {
+        // Populate source data
+        await collector.run()
+        await collector.run()
+        await collector.run()
+
+        // Harvester should process the source data
+        const result = await harvester.run()
+        assert.isTrue(result)
+
+        // Verify harvested data exists
+        const response = await harvester.retrieve()
+        assert.equal(response.status, 200)
+
+        const parsed = JSON.parse(response.content.toString())
+        assert.properties(parsed, ['averageTemperature', 'sampleCount'])
+        assert.equal(parsed.averageTemperature, 22.5)
+        assert.isAbove(parsed.sampleCount, 0)
+    })
+
+    test('source_range limits the records harvested', async ({ assert }) => {
+        // Run collector several more times
+        for (let i = 0; i < 3; i++) {
+            await collector.run()
+        }
+
+        // Run harvester again - it should process the next batch
+        const result = await harvester.run()
+        assert.isTrue(result)
+
+        const latest = await infra.db.getLatestByName(harvester.getConfiguration().name)
+        assert.isDefined(latest)
+        const data = JSON.parse((await latest!.data()).toString())
+        assert.isAtMost(data.sampleCount, 5) // source_range is 5
+    })
+})

--- a/packages/e2e/tests/harvester.spec.ts
+++ b/packages/e2e/tests/harvester.spec.ts
@@ -26,7 +26,21 @@ test.group('Harvester E2E', (group) => {
     })
 
     test('run() returns false when no source data exists', async ({ assert }) => {
-        const result = await harvester.run()
+        // Use a dedicated harvester pointing to an empty source table
+        const emptyHarvester = new (class extends WeatherAverageHarvester {
+            override getUserConfiguration() {
+                return {
+                    ...super.getUserConfiguration(),
+                    name: 'e2e_weather_avg_empty',
+                    source: 'e2e_weather_empty_source',
+                }
+            }
+        })()
+        emptyHarvester.setDependencies(infra.db, infra.storage)
+        await infra.db.createTable('e2e_weather_empty_source')
+        await infra.db.createTable('e2e_weather_avg_empty')
+
+        const result = await emptyHarvester.run()
         assert.isFalse(result)
     })
 

--- a/packages/e2e/tests/helpers/auth_helpers.ts
+++ b/packages/e2e/tests/helpers/auth_helpers.ts
@@ -1,0 +1,53 @@
+/**
+ * Auth helpers for E2E tests.
+ *
+ * Builds fake TypedRequest objects with x-user-id / x-user-roles headers.
+ * Uses db.getUserRepository().findOrCreateUser() to ensure user exists in the database.
+ */
+import type { DatabaseAdapter } from '@digitaltwin/database'
+import type { UserRecord } from '@digitaltwin/shared'
+
+interface FakeRequestOverrides {
+    params?: Record<string, string>
+    body?: Record<string, unknown>
+    query?: Record<string, string>
+    file?: {
+        path?: string
+        buffer?: Buffer
+        originalname?: string
+        mimetype?: string
+        size?: number
+    }
+}
+
+/**
+ * Create a fake HTTP request that mimics an authenticated user.
+ *
+ * When DIGITALTWIN_DISABLE_AUTH=true (set by setup.ts), the AuthMiddleware
+ * creates an anonymous user automatically. This helper is still useful for
+ * testing ownership scenarios where we need specific user IDs.
+ */
+export async function makeAuthRequest(
+    db: DatabaseAdapter,
+    keycloakId: string,
+    roles: string[] = ['user'],
+    overrides: FakeRequestOverrides = {}
+): Promise<{ headers: Record<string, string>; params: Record<string, string>; body: Record<string, unknown>; query: Record<string, string>; file?: FakeRequestOverrides['file']; userRecord: UserRecord }> {
+    // Ensure user exists in the database
+    const userRecord = await db.getUserRepository().findOrCreateUser({
+        id: keycloakId,
+        roles,
+    })
+
+    return {
+        headers: {
+            'x-user-id': keycloakId,
+            'x-user-roles': roles.join(','),
+        },
+        params: overrides.params || {},
+        body: overrides.body || {},
+        query: overrides.query || {},
+        file: overrides.file,
+        userRecord,
+    }
+}

--- a/packages/e2e/tests/helpers/fixtures.ts
+++ b/packages/e2e/tests/helpers/fixtures.ts
@@ -1,0 +1,78 @@
+/**
+ * Test fixture generators for E2E tests.
+ */
+
+/**
+ * Returns a valid GeoJSON FeatureCollection.
+ */
+export function sampleGeoJSON(): Record<string, unknown> {
+    return {
+        type: 'FeatureCollection',
+        name: 'test_points',
+        features: [
+            {
+                type: 'Feature',
+                geometry: {
+                    type: 'Point',
+                    coordinates: [4.3517, 50.8503],
+                },
+                properties: {
+                    name: 'Brussels',
+                    population: 1200000,
+                    country: 'Belgium',
+                },
+            },
+            {
+                type: 'Feature',
+                geometry: {
+                    type: 'Point',
+                    coordinates: [3.7174, 51.0543],
+                },
+                properties: {
+                    name: 'Ghent',
+                    population: 265000,
+                    country: 'Belgium',
+                },
+            },
+        ],
+    }
+}
+
+/**
+ * Creates a minimal valid 3D Tiles tileset ZIP using JSZip.
+ * Contains a tileset.json root file and a dummy tile.
+ */
+export async function sampleTilesetZip(): Promise<Buffer> {
+    const JSZip = (await import('jszip')).default
+
+    const zip = new JSZip()
+    zip.file(
+        'tileset.json',
+        JSON.stringify({
+            asset: { version: '1.0' },
+            geometricError: 500,
+            root: {
+                boundingVolume: {
+                    region: [-1.3197, 0.6988, -1.3196, 0.6989, 0, 100],
+                },
+                geometricError: 100,
+                content: { uri: 'tile.b3dm' },
+            },
+        })
+    )
+    zip.file('tile.b3dm', Buffer.from('fake-b3dm-content'))
+
+    const buf = await zip.generateAsync({ type: 'nodebuffer' })
+    return buf
+}
+
+/**
+ * Returns a minimal valid 1x1 red PNG image as a Buffer.
+ */
+export function samplePngBuffer(): Buffer {
+    // Minimal 1x1 red PNG (67 bytes)
+    return Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+        'base64'
+    )
+}

--- a/packages/e2e/tests/helpers/setup.ts
+++ b/packages/e2e/tests/helpers/setup.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared infrastructure setup for E2E tests.
+ *
+ * Starts PostgreSQL + MinIO via testcontainers (or uses env vars in CI).
+ * Exports setupInfrastructure() returning { db, storage, authMiddleware, cleanup }.
+ */
+import { GenericContainer, Wait } from 'testcontainers'
+import type { StartedTestContainer } from 'testcontainers'
+import { KyselyDatabaseAdapter } from '@digitaltwin/database'
+import { OvhS3StorageService } from '@digitaltwin/storage'
+import { AuthMiddleware, UserService } from '@digitaltwin/auth'
+import type { DatabaseAdapter } from '@digitaltwin/database'
+import type { StorageService } from '@digitaltwin/storage'
+
+const MINIO_USER = 'minioadmin'
+const MINIO_PASSWORD = 'minioadmin'
+const MINIO_BUCKET = 'test-bucket'
+
+export interface E2EInfrastructure {
+    db: DatabaseAdapter
+    storage: OvhS3StorageService
+    authMiddleware: AuthMiddleware
+    cleanup: () => Promise<void>
+}
+
+async function startMinio(): Promise<{ container: StartedTestContainer; endpoint: string }> {
+    const container = await new GenericContainer('minio/minio')
+        .withEnvironment({
+            MINIO_ROOT_USER: MINIO_USER,
+            MINIO_ROOT_PASSWORD: MINIO_PASSWORD,
+        })
+        .withCommand(['server', '/data'])
+        .withExposedPorts(9000)
+        .withWaitStrategy(Wait.forHttp('/minio/health/live', 9000))
+        .start()
+
+    const port = container.getMappedPort(9000)
+    const endpoint = `http://localhost:${port}`
+    return { container, endpoint }
+}
+
+async function createBucket(endpoint: string): Promise<void> {
+    const { S3Client, CreateBucketCommand } = await import('@aws-sdk/client-s3')
+    const accessKey = process.env.TEST_MINIO_ACCESS_KEY || MINIO_USER
+    const secretKey = process.env.TEST_MINIO_SECRET_KEY || MINIO_PASSWORD
+    const s3 = new S3Client({
+        endpoint,
+        region: 'us-east-1',
+        credentials: { accessKeyId: accessKey, secretAccessKey: secretKey },
+        forcePathStyle: true,
+        requestChecksumCalculation: 'WHEN_REQUIRED',
+        responseChecksumValidation: 'WHEN_REQUIRED',
+    })
+    try {
+        await s3.send(new CreateBucketCommand({ Bucket: MINIO_BUCKET }))
+    } catch (err: unknown) {
+        // Bucket may already exist (e.g. CI with MINIO_DEFAULT_BUCKETS)
+        const code = (err as { name?: string }).name
+        if (code !== 'BucketAlreadyOwnedByYou' && code !== 'BucketAlreadyExists') {
+            throw err
+        }
+    }
+    await s3.destroy()
+}
+
+function makeStorage(endpoint: string): OvhS3StorageService {
+    return new OvhS3StorageService({
+        accessKey: process.env.TEST_MINIO_ACCESS_KEY || MINIO_USER,
+        secretKey: process.env.TEST_MINIO_SECRET_KEY || MINIO_PASSWORD,
+        endpoint,
+        region: 'us-east-1',
+        bucket: process.env.TEST_MINIO_BUCKET || MINIO_BUCKET,
+        pathStyle: true,
+    })
+}
+
+async function startPostgres(): Promise<{ container: StartedTestContainer; host: string; port: number }> {
+    const container = await new GenericContainer('postgres:16-alpine')
+        .withEnvironment({
+            POSTGRES_USER: 'test',
+            POSTGRES_PASSWORD: 'test',
+            POSTGRES_DB: 'test',
+        })
+        .withExposedPorts(5432)
+        .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections'))
+        .start()
+
+    return {
+        container,
+        host: container.getHost(),
+        port: container.getMappedPort(5432),
+    }
+}
+
+/**
+ * Set up full E2E infrastructure: PostgreSQL + MinIO + DatabaseAdapter + StorageService + AuthMiddleware.
+ *
+ * In CI, uses env vars (TEST_PG_HOST, TEST_MINIO_ENDPOINT) if available.
+ * Otherwise, starts containers via testcontainers.
+ */
+export async function setupInfrastructure(): Promise<E2EInfrastructure> {
+    const containers: StartedTestContainer[] = []
+
+    // --- PostgreSQL ---
+    let pgHost: string
+    let pgPort: number
+    const pgUser = process.env.TEST_PG_USER || 'test'
+    const pgPassword = process.env.TEST_PG_PASSWORD || 'test'
+    const pgDatabase = process.env.TEST_PG_DATABASE || 'test'
+
+    if (process.env.TEST_PG_HOST) {
+        pgHost = process.env.TEST_PG_HOST
+        pgPort = parseInt(process.env.TEST_PG_PORT || '5432', 10)
+    } else {
+        const pg = await startPostgres()
+        containers.push(pg.container)
+        pgHost = pg.host
+        pgPort = pg.port
+    }
+
+    // --- MinIO ---
+    let minioEndpoint: string
+
+    if (process.env.TEST_MINIO_ENDPOINT) {
+        minioEndpoint = process.env.TEST_MINIO_ENDPOINT
+    } else {
+        const minio = await startMinio()
+        containers.push(minio.container)
+        minioEndpoint = minio.endpoint
+    }
+
+    await createBucket(minioEndpoint)
+
+    // --- Storage ---
+    const storage = makeStorage(minioEndpoint)
+
+    // --- Database ---
+    const dataResolver = async (url: string) => storage.retrieve(url)
+    const db = await KyselyDatabaseAdapter.forPostgreSQL(
+        { host: pgHost, port: pgPort, user: pgUser, password: pgPassword, database: pgDatabase },
+        dataResolver
+    )
+
+    // Initialize user tables (needed for auth)
+    await db.getUserRepository().initializeTables()
+
+    // --- Auth ---
+    // Disable auth for simpler E2E testing — auth_helpers.ts simulates it
+    process.env.DIGITALTWIN_DISABLE_AUTH = 'true'
+    const userService = new UserService(db.getUserRepository())
+    const authMiddleware = new AuthMiddleware(userService)
+
+    return {
+        db,
+        storage,
+        authMiddleware,
+        cleanup: async () => {
+            await db.close()
+            for (const c of containers) {
+                await c.stop()
+            }
+        },
+    }
+}

--- a/packages/e2e/tests/helpers/test_components.ts
+++ b/packages/e2e/tests/helpers/test_components.ts
@@ -1,0 +1,170 @@
+/**
+ * Concrete component classes for E2E tests.
+ *
+ * These provide real (non-mocked) behavior to verify the full pipeline
+ * from component → database → storage and back.
+ */
+import { Collector, Harvester, Handler, CustomTableManager } from '@digitaltwin/components'
+import { AssetsManager, TilesetManager, MapManager } from '@digitaltwin/assets'
+import { servableEndpoint } from '@digitaltwin/shared'
+import type {
+    CollectorConfiguration,
+    HarvesterConfiguration,
+    AssetsManagerConfiguration,
+    StoreConfiguration,
+    ComponentConfiguration,
+    DataResponse,
+    DataRecord,
+    TypedRequest,
+} from '@digitaltwin/shared'
+
+// ── Collector ────────────────────────────────────────────────────────────────
+
+export class WeatherCollector extends Collector {
+    getConfiguration(): CollectorConfiguration {
+        return {
+            name: 'e2e_weather',
+            description: 'E2E weather data collector',
+            contentType: 'application/json',
+            endpoint: 'e2e-weather',
+        }
+    }
+
+    getSchedule(): string {
+        return '0 */15 * * * *'
+    }
+
+    async collect(): Promise<Buffer> {
+        const data = {
+            temperature: 22.5,
+            humidity: 65,
+            pressure: 1013.25,
+            timestamp: new Date().toISOString(),
+        }
+        return Buffer.from(JSON.stringify(data))
+    }
+}
+
+// ── Harvester ────────────────────────────────────────────────────────────────
+
+export class WeatherAverageHarvester extends Harvester {
+    getUserConfiguration(): HarvesterConfiguration {
+        return {
+            name: 'e2e_weather_avg',
+            description: 'E2E weather average harvester',
+            contentType: 'application/json',
+            endpoint: 'e2e-weather-avg',
+            source: 'e2e_weather',
+            source_range: 5,
+            triggerMode: 'schedule',
+        }
+    }
+
+    async harvest(
+        sourceData: DataRecord | DataRecord[],
+        _dependenciesData: Record<string, DataRecord | DataRecord[] | null>
+    ): Promise<Buffer> {
+        const records = Array.isArray(sourceData) ? sourceData : [sourceData]
+        const temps: number[] = []
+
+        for (const record of records) {
+            const buf = await record.data()
+            const parsed = JSON.parse(buf.toString())
+            if (typeof parsed.temperature === 'number') {
+                temps.push(parsed.temperature)
+            }
+        }
+
+        const avg = temps.length > 0 ? temps.reduce((a, b) => a + b, 0) / temps.length : 0
+        return Buffer.from(JSON.stringify({ averageTemperature: avg, sampleCount: temps.length }))
+    }
+}
+
+// ── Handler ──────────────────────────────────────────────────────────────────
+
+export class CalculatorHandler extends Handler {
+    getConfiguration(): ComponentConfiguration {
+        return {
+            name: 'e2e_calculator',
+            description: 'E2E calculator handler',
+            contentType: 'application/json',
+        }
+    }
+
+    @servableEndpoint({ path: '/e2e-calculator/sum', method: 'post' })
+    async calculateSum(req: TypedRequest): Promise<DataResponse> {
+        const body = req.body as { a: number; b: number }
+        return {
+            status: 200,
+            content: JSON.stringify({ result: body.a + body.b }),
+            headers: { 'Content-Type': 'application/json' },
+        }
+    }
+
+    @servableEndpoint({ path: '/e2e-calculator/health', method: 'get' })
+    async healthCheck(): Promise<DataResponse> {
+        return {
+            status: 200,
+            content: JSON.stringify({ status: 'ok' }),
+            headers: { 'Content-Type': 'application/json' },
+        }
+    }
+}
+
+// ── AssetsManager ────────────────────────────────────────────────────────────
+
+export class E2EAssetsManager extends AssetsManager {
+    getConfiguration(): AssetsManagerConfiguration {
+        return {
+            name: 'e2e_assets',
+            description: 'E2E asset manager',
+            contentType: 'application/octet-stream',
+            endpoint: 'e2e-assets',
+            extension: '.bin',
+        }
+    }
+}
+
+// ── TilesetManager ───────────────────────────────────────────────────────────
+
+export class E2ETilesetManager extends TilesetManager {
+    getConfiguration(): AssetsManagerConfiguration {
+        return {
+            name: 'e2e_tilesets',
+            description: 'E2E tileset manager',
+            contentType: 'application/json',
+            endpoint: 'e2e-tilesets',
+            extension: '.zip',
+        }
+    }
+}
+
+// ── MapManager ───────────────────────────────────────────────────────────────
+
+export class E2EMapManager extends MapManager {
+    getConfiguration(): AssetsManagerConfiguration {
+        return {
+            name: 'e2e_maps',
+            description: 'E2E map manager',
+            contentType: 'application/json',
+            endpoint: 'e2e-maps',
+            extension: '.json',
+        }
+    }
+}
+
+// ── CustomTableManager ───────────────────────────────────────────────────────
+
+export class E2ECustomTableManager extends CustomTableManager {
+    getConfiguration(): StoreConfiguration {
+        return {
+            name: 'e2e_custom_records',
+            description: 'E2E custom table for testing CRUD',
+            columns: {
+                title: 'text not null',
+                value: 'integer default 0',
+                active: 'boolean default true',
+            },
+        }
+    }
+}

--- a/packages/e2e/tests/http_integration.spec.ts
+++ b/packages/e2e/tests/http_integration.spec.ts
@@ -1,0 +1,343 @@
+/**
+ * HTTP Integration Tests
+ *
+ * Starts the real DigitalTwinEngine with Express, sends HTTP requests
+ * with x-user-id / x-user-roles headers (simulating APISIX gateway),
+ * and verifies full-stack responses.
+ */
+import { test } from '@japa/runner'
+import { RedisContainer } from '@testcontainers/redis'
+import type { StartedRedisContainer } from '@testcontainers/redis'
+import { setupInfrastructure, type E2EInfrastructure } from './helpers/setup.js'
+import { DigitalTwinEngine } from '@digitaltwin/engine'
+import { AuthConfig } from '@digitaltwin/auth'
+import { LogLevel } from '@digitaltwin/shared'
+import {
+    WeatherCollector,
+    CalculatorHandler,
+    E2ECustomTableManager,
+} from './helpers/test_components.js'
+
+const ENGINE_PORT = 19876
+
+test.group('HTTP Integration — Engine + APISIX headers', (group) => {
+    let infra: E2EInfrastructure
+    let redis: StartedRedisContainer
+    let engine: DigitalTwinEngine
+    let collector: WeatherCollector
+    let baseUrl: string
+
+    group.setup(async () => {
+        // --- Infrastructure ---
+        infra = await setupInfrastructure()
+
+        // Start Redis for queue manager
+        redis = await new RedisContainer('redis:7-alpine').start()
+
+        // --- Auth: ENABLED (not disabled) so APISIX header parsing is active ---
+        delete process.env.DIGITALTWIN_DISABLE_AUTH
+        AuthConfig._resetConfig()
+
+        // Reset ApisixAuthParser cached provider
+        const { ApisixAuthParser } = await import('@digitaltwin/auth')
+        ApisixAuthParser._resetProvider()
+
+        // --- Components ---
+        collector = new WeatherCollector()
+        const handler = new CalculatorHandler()
+        const customTable = new E2ECustomTableManager()
+
+        // --- Engine ---
+        engine = new DigitalTwinEngine({
+            database: infra.db,
+            storage: infra.storage,
+            collectors: [collector],
+            handlers: [handler],
+            customTableManagers: [customTable],
+            redis: {
+                host: redis.getHost(),
+                port: redis.getMappedPort(6379),
+            },
+            server: { port: ENGINE_PORT },
+            logging: { level: LogLevel.SILENT },
+            queues: { multiQueue: true },
+        })
+
+        await engine.start()
+        baseUrl = `http://localhost:${ENGINE_PORT}`
+
+        // Manually run the collector so its retrieve endpoint has data
+        // (the cron schedule is every 15 min, too slow for tests)
+        await collector.run()
+    })
+
+    group.teardown(async () => {
+        try {
+            await Promise.race([
+                engine.stop(),
+                new Promise((_, reject) =>
+                    setTimeout(() => reject(new Error('Engine stop timeout')), 5000)
+                ),
+            ])
+        } catch {
+            // Ignore shutdown errors
+        }
+
+        // Restore disabled auth for other test groups
+        process.env.DIGITALTWIN_DISABLE_AUTH = 'true'
+        AuthConfig._resetConfig()
+
+        await redis.stop()
+        await infra.cleanup()
+    })
+
+    // ── Health endpoints ──────────────────────────────────────────────────
+
+    test('GET /api/health/live returns 200', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/api/health/live`)
+        assert.equal(res.status, 200)
+
+        const body = await res.json()
+        assert.equal(body.status, 'ok')
+    })
+
+    test('GET /api/health/ready returns 200', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/api/health/ready`)
+        assert.oneOf(res.status, [200, 503])
+    })
+
+    // ── Handler endpoints (no auth required) ──────────────────────────────
+
+    test('GET /e2e-calculator/health returns 200', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/e2e-calculator/health`)
+        assert.equal(res.status, 200)
+
+        const body = await res.json()
+        assert.equal(body.status, 'ok')
+    })
+
+    test('POST /e2e-calculator/sum computes result', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/e2e-calculator/sum`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ a: 17, b: 25 }),
+        })
+        assert.equal(res.status, 200)
+
+        const body = await res.json()
+        assert.equal(body.result, 42)
+    })
+
+    // ── Collector endpoint ────────────────────────────────────────────────
+
+    test('GET /e2e-weather returns collected data', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/e2e-weather`)
+        assert.equal(res.status, 200)
+
+        const body = await res.json()
+        assert.properties(body, ['temperature', 'humidity', 'pressure', 'timestamp'])
+        assert.equal(body.temperature, 22.5)
+    })
+
+    // ── CustomTableManager CRUD with APISIX headers ────────────────────────
+
+    test('POST /{table} without auth headers returns 401', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/e2e_custom_records`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ title: 'No Auth', value: 0 }),
+        })
+        assert.equal(res.status, 401)
+    })
+
+    test('POST /{table} with APISIX headers creates record', async ({ assert }) => {
+        // Ensure user exists in DB first
+        await infra.db.getUserRepository().findOrCreateUser({
+            id: 'http-user-1',
+            roles: ['user'],
+        })
+
+        const res = await fetch(`${baseUrl}/e2e_custom_records`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-user-id': 'http-user-1',
+                'x-user-roles': 'user',
+            },
+            body: JSON.stringify({ title: 'HTTP Created', value: 42, active: true }),
+        })
+        assert.equal(res.status, 201)
+
+        const body = await res.json()
+        assert.property(body, 'id')
+        assert.isAbove(body.id, 0)
+    })
+
+    test('GET /{table} returns all records', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/e2e_custom_records`)
+        assert.equal(res.status, 200)
+
+        const body = await res.json()
+        assert.isArray(body)
+        assert.isAbove(body.length, 0)
+    })
+
+    test('GET /{table}/:id returns specific record', async ({ assert }) => {
+        // Create a record first
+        await infra.db.getUserRepository().findOrCreateUser({
+            id: 'http-user-2',
+            roles: ['user'],
+        })
+
+        const createRes = await fetch(`${baseUrl}/e2e_custom_records`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-user-id': 'http-user-2',
+                'x-user-roles': 'user',
+            },
+            body: JSON.stringify({ title: 'Fetchable Record', value: 99 }),
+        })
+        const { id } = await createRes.json()
+
+        const res = await fetch(`${baseUrl}/e2e_custom_records/${id}`)
+        assert.equal(res.status, 200)
+
+        const body = await res.json()
+        assert.equal(body.title, 'Fetchable Record')
+        assert.equal(body.value, 99)
+    })
+
+    test('PUT /{table}/:id as owner updates record', async ({ assert }) => {
+        await infra.db.getUserRepository().findOrCreateUser({
+            id: 'http-user-3',
+            roles: ['user'],
+        })
+
+        const createRes = await fetch(`${baseUrl}/e2e_custom_records`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-user-id': 'http-user-3',
+                'x-user-roles': 'user',
+            },
+            body: JSON.stringify({ title: 'Original Title', value: 10 }),
+        })
+        const { id } = await createRes.json()
+
+        const res = await fetch(`${baseUrl}/e2e_custom_records/${id}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-user-id': 'http-user-3',
+                'x-user-roles': 'user',
+            },
+            body: JSON.stringify({ title: 'Updated Title', value: 20 }),
+        })
+        assert.equal(res.status, 200)
+    })
+
+    test('PUT /{table}/:id as non-owner returns 403', async ({ assert }) => {
+        // Create record as user A
+        await infra.db.getUserRepository().findOrCreateUser({
+            id: 'http-owner-a',
+            roles: ['user'],
+        })
+        await infra.db.getUserRepository().findOrCreateUser({
+            id: 'http-owner-b',
+            roles: ['user'],
+        })
+
+        const createRes = await fetch(`${baseUrl}/e2e_custom_records`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-user-id': 'http-owner-a',
+                'x-user-roles': 'user',
+            },
+            body: JSON.stringify({ title: 'Owned by A', value: 1 }),
+        })
+        const { id } = await createRes.json()
+
+        // Try to update as user B
+        const res = await fetch(`${baseUrl}/e2e_custom_records/${id}`, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-user-id': 'http-owner-b',
+                'x-user-roles': 'user',
+            },
+            body: JSON.stringify({ title: 'Hacked by B' }),
+        })
+        assert.equal(res.status, 403)
+    })
+
+    test('DELETE /{table}/:id as owner succeeds', async ({ assert }) => {
+        await infra.db.getUserRepository().findOrCreateUser({
+            id: 'http-user-del',
+            roles: ['user'],
+        })
+
+        const createRes = await fetch(`${baseUrl}/e2e_custom_records`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-user-id': 'http-user-del',
+                'x-user-roles': 'user',
+            },
+            body: JSON.stringify({ title: 'To Be Deleted', value: 0 }),
+        })
+        const { id } = await createRes.json()
+
+        const res = await fetch(`${baseUrl}/e2e_custom_records/${id}`, {
+            method: 'DELETE',
+            headers: {
+                'x-user-id': 'http-user-del',
+                'x-user-roles': 'user',
+            },
+        })
+        assert.equal(res.status, 200)
+
+        // Verify deletion
+        const getRes = await fetch(`${baseUrl}/e2e_custom_records/${id}`)
+        assert.equal(getRes.status, 404)
+    })
+
+    test('DELETE /{table}/:id as non-owner returns 403', async ({ assert }) => {
+        await infra.db.getUserRepository().findOrCreateUser({
+            id: 'http-del-owner',
+            roles: ['user'],
+        })
+        await infra.db.getUserRepository().findOrCreateUser({
+            id: 'http-del-attacker',
+            roles: ['user'],
+        })
+
+        const createRes = await fetch(`${baseUrl}/e2e_custom_records`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'x-user-id': 'http-del-owner',
+                'x-user-roles': 'user',
+            },
+            body: JSON.stringify({ title: 'Protected Record', value: 777 }),
+        })
+        const { id } = await createRes.json()
+
+        const res = await fetch(`${baseUrl}/e2e_custom_records/${id}`, {
+            method: 'DELETE',
+            headers: {
+                'x-user-id': 'http-del-attacker',
+                'x-user-roles': 'user',
+            },
+        })
+        assert.equal(res.status, 403)
+    })
+
+    // ── 404 for unknown routes ────────────────────────────────────────────
+
+    test('GET /nonexistent returns 404', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/nonexistent`)
+        assert.equal(res.status, 404)
+    })
+})

--- a/packages/e2e/tests/map_manager.spec.ts
+++ b/packages/e2e/tests/map_manager.spec.ts
@@ -1,0 +1,82 @@
+import { test } from '@japa/runner'
+import { setupInfrastructure, type E2EInfrastructure } from './helpers/setup.js'
+import { makeAuthRequest } from './helpers/auth_helpers.js'
+import { E2EMapManager } from './helpers/test_components.js'
+import { sampleGeoJSON } from './helpers/fixtures.js'
+import type { TypedRequest } from '@digitaltwin/shared'
+
+test.group('MapManager E2E', (group) => {
+    let infra: E2EInfrastructure
+    let manager: E2EMapManager
+
+    group.setup(async () => {
+        infra = await setupInfrastructure()
+        manager = new E2EMapManager()
+        manager.setDependencies(infra.db, infra.storage, infra.authMiddleware)
+
+        const config = manager.getConfiguration()
+        await infra.db.createTable(config.name)
+        await infra.db.ensureColumns(config.name, {
+            description: 'text',
+            source: 'text',
+            owner_id: 'integer',
+            filename: 'text',
+            is_public: 'boolean default true',
+            layer_type: 'text',
+            layer_name: 'text',
+            geometry_type: 'text',
+            properties_count: 'integer',
+        })
+    })
+
+    group.teardown(async () => {
+        await infra.cleanup()
+    })
+
+    test('upload GeoJSON layer via body', async ({ assert }) => {
+        const geojson = sampleGeoJSON()
+
+        const req = await makeAuthRequest(infra.db, 'user-map-1', ['user'], {
+            body: {
+                layer: geojson,
+                description: 'Test map layer',
+                source: 'https://example.com/geo',
+            },
+        })
+
+        const response = await manager.handleUpload(req as unknown as TypedRequest)
+        assert.equal(response.status, 200)
+
+        const parsed = JSON.parse(response.content as string)
+        assert.equal(parsed.geometry_type, 'point')
+        assert.equal(parsed.properties_count, 3)
+        assert.equal(parsed.layer_name, 'test_points')
+    })
+
+    test('uploaded layer metadata is analyzed correctly', async ({ assert }) => {
+        const config = manager.getConfiguration()
+        const latest = await infra.db.getLatestByName(config.name)
+        assert.isDefined(latest)
+
+        // Verify the layer data is stored and retrievable
+        const blob = await latest!.data()
+        const stored = JSON.parse(blob.toString())
+        assert.equal(stored.type, 'FeatureCollection')
+        assert.isArray(stored.features)
+        assert.equal(stored.features.length, 2)
+    })
+
+    test('retrieve lists all layers with metadata', async ({ assert }) => {
+        const response = await manager.retrieve()
+        assert.equal(response.status, 200)
+
+        const layers = JSON.parse(response.content as string)
+        assert.isArray(layers)
+        assert.isAbove(layers.length, 0)
+
+        const layer = layers[0]
+        assert.property(layer, 'layer_type')
+        assert.property(layer, 'geometry_type')
+        assert.property(layer, 'properties_count')
+    })
+})

--- a/packages/e2e/tests/tileset_manager.spec.ts
+++ b/packages/e2e/tests/tileset_manager.spec.ts
@@ -1,0 +1,85 @@
+import { test } from '@japa/runner'
+import { setupInfrastructure, type E2EInfrastructure } from './helpers/setup.js'
+import { makeAuthRequest } from './helpers/auth_helpers.js'
+import { E2ETilesetManager } from './helpers/test_components.js'
+import { sampleTilesetZip } from './helpers/fixtures.js'
+import type { TypedRequest } from '@digitaltwin/shared'
+
+test.group('TilesetManager E2E', (group) => {
+    let infra: E2EInfrastructure
+    let manager: E2ETilesetManager
+
+    group.setup(async () => {
+        infra = await setupInfrastructure()
+        manager = new E2ETilesetManager()
+        manager.setDependencies(infra.db, infra.storage, infra.authMiddleware)
+
+        const config = manager.getConfiguration()
+        await infra.db.createTable(config.name)
+        await infra.db.ensureColumns(config.name, {
+            description: 'text',
+            source: 'text',
+            owner_id: 'integer',
+            filename: 'text',
+            is_public: 'boolean default true',
+            tileset_url: 'text',
+            upload_status: 'text',
+            upload_error: 'text',
+            upload_job_id: 'text',
+            presigned_key: 'text',
+            presigned_expires_at: 'timestamp',
+        })
+    })
+
+    group.teardown(async () => {
+        await infra.cleanup()
+    })
+
+    test('handleUpload sync uploads small ZIP, extracts to MinIO, sets tileset_url', async ({ assert }) => {
+        const zipBuffer = await sampleTilesetZip()
+
+        const req = await makeAuthRequest(infra.db, 'user-tileset-1', ['user'], {
+            body: {
+                description: 'E2E test tileset',
+            },
+        })
+
+        // Simulate multer file
+        const fileReq = {
+            ...req,
+            file: {
+                buffer: zipBuffer,
+                originalname: 'test-tileset.zip',
+                mimetype: 'application/zip',
+                size: zipBuffer.length,
+            },
+        } as unknown as TypedRequest
+
+        const response = await manager.handleUpload(fileReq)
+        assert.equal(response.status, 200)
+
+        const parsed = JSON.parse(response.content as string)
+        assert.property(parsed, 'tileset_url')
+        assert.include(parsed.tileset_url, 'tileset.json')
+    })
+
+    test('uploaded tileset files are retrievable from storage', async ({ assert }) => {
+        const config = manager.getConfiguration()
+        const latest = await infra.db.getLatestByName(config.name)
+        assert.isDefined(latest)
+
+        // The tileset_url should point to a stored tileset.json
+        if (latest?.tileset_url) {
+            // Extract the storage key from the URL
+            // For MinIO with pathStyle, the key is the path after the bucket
+            const url = new URL(latest.tileset_url)
+            const key = url.pathname.replace(`/${process.env.TEST_MINIO_BUCKET || 'test-bucket'}/`, '').replace(/^\//, '')
+
+            const content = await infra.storage.retrieve(key)
+            assert.instanceOf(content, Buffer)
+            const tilesetJson = JSON.parse(content.toString())
+            assert.property(tilesetJson, 'asset')
+            assert.equal(tilesetJson.asset.version, '1.0')
+        }
+    })
+})

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true
+  },
+  "include": ["tests", "bin"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/e2e/tsconfig.test.json
+++ b/packages/e2e/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["tests", "bin"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,58 @@ importers:
         specifier: ^10.9.5
         version: 10.9.6(@types/node@24.10.8)(typescript@5.9.3)
 
+  packages/e2e:
+    dependencies:
+      '@digitaltwin/assets':
+        specifier: workspace:*
+        version: link:../assets
+      '@digitaltwin/auth':
+        specifier: workspace:*
+        version: link:../auth
+      '@digitaltwin/components':
+        specifier: workspace:*
+        version: link:../components
+      '@digitaltwin/database':
+        specifier: workspace:*
+        version: link:../database
+      '@digitaltwin/engine':
+        specifier: workspace:*
+        version: link:../engine
+      '@digitaltwin/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@digitaltwin/storage':
+        specifier: workspace:*
+        version: link:../storage
+    devDependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1002.0
+        version: 3.1002.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1002.0
+        version: 3.1002.0
+      '@japa/assert':
+        specifier: ^4.1.0
+        version: 4.2.0(@japa/runner@4.5.0)
+      '@japa/runner':
+        specifier: ^4.3.0
+        version: 4.5.0
+      '@testcontainers/redis':
+        specifier: ^11.3.1
+        version: 11.11.0
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
+      pg:
+        specifier: ^8.16.0
+        version: 8.20.0
+      testcontainers:
+        specifier: ^10.0.0
+        version: 10.28.0
+      ts-node-maintained:
+        specifier: ^10.9.5
+        version: 10.9.6(@types/node@24.10.8)(typescript@5.9.3)
+
   packages/engine:
     dependencies:
       '@digitaltwin/assets':
@@ -1285,10 +1337,6 @@ packages:
     resolution: {integrity: sha512-Sf39Ml0iVX+ba/bgMPxaXWAAFmHqYLTmbjAPfLPLY8CrYkRDEqZdUsKC1OwVMCdJXfAt0v4j49GIJ8DoSYAe6w==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/eventstream-codec@4.2.8':
-    resolution: {integrity: sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/eventstream-serde-browser@4.2.11':
     resolution: {integrity: sha512-3rEpo3G6f/nRS7fQDsZmxw/ius6rnlIpz4UX6FlALEzz8JoSxFmdBt0SZnthis+km7sQo6q5/3e+UJcuQivoXA==}
     engines: {node: '>=18.0.0'}
@@ -1615,10 +1663,6 @@ packages:
 
   '@smithy/util-stream@4.5.17':
     resolution: {integrity: sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-uri-escape@4.2.0':
-    resolution: {integrity: sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.2':
@@ -4041,13 +4085,13 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/types': 3.973.4
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/types': 3.973.4
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
@@ -4081,7 +4125,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/types': 3.973.4
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -4209,41 +4253,41 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.5
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.5
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/core': 3.973.17
+      '@aws-sdk/middleware-host-header': 3.972.6
+      '@aws-sdk/middleware-logger': 3.972.6
+      '@aws-sdk/middleware-recursion-detection': 3.972.6
+      '@aws-sdk/middleware-user-agent': 3.972.17
+      '@aws-sdk/region-config-resolver': 3.972.6
+      '@aws-sdk/types': 3.973.4
       '@aws-sdk/util-endpoints': 3.980.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.3
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.22.1
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.13
-      '@smithy/middleware-retry': 4.4.30
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.9
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.2
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.29
-      '@smithy/util-defaults-mode-node': 4.2.32
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@aws-sdk/util-user-agent-browser': 3.972.6
+      '@aws-sdk/util-user-agent-node': 3.973.2
+      '@smithy/config-resolver': 4.4.10
+      '@smithy/core': 3.23.8
+      '@smithy/fetch-http-handler': 5.3.13
+      '@smithy/hash-node': 4.2.11
+      '@smithy/invalid-dependency': 4.2.11
+      '@smithy/middleware-content-length': 4.2.11
+      '@smithy/middleware-endpoint': 4.4.22
+      '@smithy/middleware-retry': 4.4.39
+      '@smithy/middleware-serde': 4.2.12
+      '@smithy/middleware-stack': 4.2.11
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/node-http-handler': 4.4.14
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/smithy-client': 4.12.2
+      '@smithy/types': 4.13.0
+      '@smithy/url-parser': 4.2.11
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.38
+      '@smithy/util-defaults-mode-node': 4.2.41
+      '@smithy/util-endpoints': 3.3.2
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-retry': 4.2.11
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4282,7 +4326,7 @@ snapshots:
 
   '@aws-sdk/crc64-nvme@3.972.0':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@aws-sdk/crc64-nvme@3.972.3':
@@ -4300,10 +4344,10 @@ snapshots:
 
   '@aws-sdk/credential-provider-env@3.972.3':
     dependencies:
-      '@aws-sdk/core': 3.973.5
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/types': 4.12.0
+      '@aws-sdk/core': 3.973.17
+      '@aws-sdk/types': 3.973.4
+      '@smithy/property-provider': 4.2.11
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.17':
@@ -4321,15 +4365,15 @@ snapshots:
 
   '@aws-sdk/credential-provider-http@3.972.5':
     dependencies:
-      '@aws-sdk/core': 3.973.5
-      '@aws-sdk/types': 3.973.1
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/node-http-handler': 4.4.9
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.2
-      '@smithy/types': 4.12.0
-      '@smithy/util-stream': 4.5.11
+      '@aws-sdk/core': 3.973.17
+      '@aws-sdk/types': 3.973.4
+      '@smithy/fetch-http-handler': 5.3.13
+      '@smithy/node-http-handler': 4.4.14
+      '@smithy/property-provider': 4.2.11
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/smithy-client': 4.12.2
+      '@smithy/types': 4.13.0
+      '@smithy/util-stream': 4.5.17
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.15':
@@ -4353,19 +4397,19 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.972.3':
     dependencies:
-      '@aws-sdk/core': 3.973.5
-      '@aws-sdk/credential-provider-env': 3.972.3
-      '@aws-sdk/credential-provider-http': 3.972.5
+      '@aws-sdk/core': 3.973.17
+      '@aws-sdk/credential-provider-env': 3.972.15
+      '@aws-sdk/credential-provider-http': 3.972.17
       '@aws-sdk/credential-provider-login': 3.972.3
-      '@aws-sdk/credential-provider-process': 3.972.3
-      '@aws-sdk/credential-provider-sso': 3.972.3
-      '@aws-sdk/credential-provider-web-identity': 3.972.3
+      '@aws-sdk/credential-provider-process': 3.972.15
+      '@aws-sdk/credential-provider-sso': 3.972.15
+      '@aws-sdk/credential-provider-web-identity': 3.972.15
       '@aws-sdk/nested-clients': 3.980.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/credential-provider-imds': 4.2.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/types': 3.973.4
+      '@smithy/credential-provider-imds': 4.2.11
+      '@smithy/property-provider': 4.2.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4385,13 +4429,13 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.3':
     dependencies:
-      '@aws-sdk/core': 3.973.5
+      '@aws-sdk/core': 3.973.17
       '@aws-sdk/nested-clients': 3.980.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/types': 3.973.4
+      '@smithy/property-provider': 4.2.11
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4441,11 +4485,11 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.3':
     dependencies:
-      '@aws-sdk/core': 3.973.5
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/core': 3.973.17
+      '@aws-sdk/types': 3.973.4
+      '@smithy/property-provider': 4.2.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.15':
@@ -4464,12 +4508,12 @@ snapshots:
   '@aws-sdk/credential-provider-sso@3.972.3':
     dependencies:
       '@aws-sdk/client-sso': 3.980.0
-      '@aws-sdk/core': 3.973.5
+      '@aws-sdk/core': 3.973.17
       '@aws-sdk/token-providers': 3.980.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/types': 3.973.4
+      '@smithy/property-provider': 4.2.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4488,12 +4532,12 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.972.3':
     dependencies:
-      '@aws-sdk/core': 3.973.5
+      '@aws-sdk/core': 3.973.17
       '@aws-sdk/nested-clients': 3.980.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/types': 3.973.4
+      '@smithy/property-provider': 4.2.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4690,41 +4734,41 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.5
-      '@aws-sdk/middleware-host-header': 3.972.3
-      '@aws-sdk/middleware-logger': 3.972.3
-      '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.5
-      '@aws-sdk/region-config-resolver': 3.972.3
-      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/core': 3.973.17
+      '@aws-sdk/middleware-host-header': 3.972.6
+      '@aws-sdk/middleware-logger': 3.972.6
+      '@aws-sdk/middleware-recursion-detection': 3.972.6
+      '@aws-sdk/middleware-user-agent': 3.972.17
+      '@aws-sdk/region-config-resolver': 3.972.6
+      '@aws-sdk/types': 3.973.4
       '@aws-sdk/util-endpoints': 3.980.0
-      '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.3
-      '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.22.1
-      '@smithy/fetch-http-handler': 5.3.9
-      '@smithy/hash-node': 4.2.8
-      '@smithy/invalid-dependency': 4.2.8
-      '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.13
-      '@smithy/middleware-retry': 4.4.30
-      '@smithy/middleware-serde': 4.2.9
-      '@smithy/middleware-stack': 4.2.8
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.9
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.2
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.29
-      '@smithy/util-defaults-mode-node': 4.2.32
-      '@smithy/util-endpoints': 3.2.8
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-retry': 4.2.8
-      '@smithy/util-utf8': 4.2.0
+      '@aws-sdk/util-user-agent-browser': 3.972.6
+      '@aws-sdk/util-user-agent-node': 3.973.2
+      '@smithy/config-resolver': 4.4.10
+      '@smithy/core': 3.23.8
+      '@smithy/fetch-http-handler': 5.3.13
+      '@smithy/hash-node': 4.2.11
+      '@smithy/invalid-dependency': 4.2.11
+      '@smithy/middleware-content-length': 4.2.11
+      '@smithy/middleware-endpoint': 4.4.22
+      '@smithy/middleware-retry': 4.4.39
+      '@smithy/middleware-serde': 4.2.12
+      '@smithy/middleware-stack': 4.2.11
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/node-http-handler': 4.4.14
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/smithy-client': 4.12.2
+      '@smithy/types': 4.13.0
+      '@smithy/url-parser': 4.2.11
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.38
+      '@smithy/util-defaults-mode-node': 4.2.41
+      '@smithy/util-endpoints': 3.3.2
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-retry': 4.2.11
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4831,12 +4875,12 @@ snapshots:
 
   '@aws-sdk/token-providers@3.980.0':
     dependencies:
-      '@aws-sdk/core': 3.973.5
+      '@aws-sdk/core': 3.973.17
       '@aws-sdk/nested-clients': 3.980.0
-      '@aws-sdk/types': 3.973.1
-      '@smithy/property-provider': 4.2.8
-      '@smithy/shared-ini-file-loader': 4.4.3
-      '@smithy/types': 4.12.0
+      '@aws-sdk/types': 3.973.4
+      '@smithy/property-provider': 4.2.11
+      '@smithy/shared-ini-file-loader': 4.4.6
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4857,10 +4901,10 @@ snapshots:
 
   '@aws-sdk/util-endpoints@3.980.0':
     dependencies:
-      '@aws-sdk/types': 3.973.1
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
-      '@smithy/util-endpoints': 3.2.8
+      '@aws-sdk/types': 3.973.4
+      '@smithy/types': 4.13.0
+      '@smithy/url-parser': 4.2.11
+      '@smithy/util-endpoints': 3.3.2
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.981.0':
@@ -4922,7 +4966,7 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.972.3':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
       fast-xml-parser: 5.3.4
       tslib: 2.8.1
 
@@ -5340,12 +5384,12 @@ snapshots:
 
   '@smithy/abort-controller@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@smithy/chunked-blob-reader-native@4.2.1':
     dependencies:
-      '@smithy/util-base64': 4.3.0
+      '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
   '@smithy/chunked-blob-reader-native@4.2.3':
@@ -5415,10 +5459,10 @@ snapshots:
 
   '@smithy/credential-provider-imds@4.2.8':
     dependencies:
-      '@smithy/node-config-provider': 4.3.8
-      '@smithy/property-provider': 4.2.8
-      '@smithy/types': 4.12.0
-      '@smithy/url-parser': 4.2.8
+      '@smithy/node-config-provider': 4.3.11
+      '@smithy/property-provider': 4.2.11
+      '@smithy/types': 4.13.0
+      '@smithy/url-parser': 4.2.11
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.11':
@@ -5426,13 +5470,6 @@ snapshots:
       '@aws-crypto/crc32': 5.2.0
       '@smithy/types': 4.13.0
       '@smithy/util-hex-encoding': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/eventstream-codec@4.2.8':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.12.0
-      '@smithy/util-hex-encoding': 4.2.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-browser@4.2.11':
@@ -5477,8 +5514,8 @@ snapshots:
 
   '@smithy/eventstream-serde-universal@4.2.8':
     dependencies:
-      '@smithy/eventstream-codec': 4.2.8
-      '@smithy/types': 4.12.0
+      '@smithy/eventstream-codec': 4.2.11
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.3.13':
@@ -5688,7 +5725,7 @@ snapshots:
 
   '@smithy/property-provider@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.11':
@@ -5709,8 +5746,8 @@ snapshots:
 
   '@smithy/querystring-builder@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
-      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/types': 4.13.0
+      '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.2.11':
@@ -5720,7 +5757,7 @@ snapshots:
 
   '@smithy/querystring-parser@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@smithy/service-error-classification@4.2.11':
@@ -5729,11 +5766,11 @@ snapshots:
 
   '@smithy/service-error-classification@4.2.8':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
 
   '@smithy/shared-ini-file-loader@4.4.3':
     dependencies:
-      '@smithy/types': 4.12.0
+      '@smithy/types': 4.13.0
       tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.4.6':
@@ -5754,13 +5791,13 @@ snapshots:
 
   '@smithy/signature-v4@5.3.8':
     dependencies:
-      '@smithy/is-array-buffer': 4.2.0
-      '@smithy/protocol-http': 5.3.8
-      '@smithy/types': 4.12.0
-      '@smithy/util-hex-encoding': 4.2.0
-      '@smithy/util-middleware': 4.2.8
-      '@smithy/util-uri-escape': 4.2.0
-      '@smithy/util-utf8': 4.2.0
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.11
+      '@smithy/types': 4.13.0
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.11
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/smithy-client@4.11.2':
@@ -5838,7 +5875,7 @@ snapshots:
 
   '@smithy/util-buffer-from@4.2.0':
     dependencies:
-      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/is-array-buffer': 4.2.2
       tslib: 2.8.1
 
   '@smithy/util-buffer-from@4.2.2':
@@ -5950,10 +5987,6 @@ snapshots:
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-
-  '@smithy/util-uri-escape@4.2.0':
-    dependencies:
       tslib: 2.8.1
 
   '@smithy/util-uri-escape@4.2.2':


### PR DESCRIPTION
## Summary
- New `@digitaltwin/e2e` package with **43 tests** covering all component types
- Direct component tests: Collector, Harvester, Handler, AssetsManager (presigned upload), TilesetManager, MapManager, CustomTableManager (CRUD + ownership)
- HTTP integration tests: real `DigitalTwinEngine` with Express, APISIX header auth (`x-user-id`/`x-user-roles`), 401/403 enforcement, health endpoints
- Infrastructure via testcontainers: PostgreSQL, MinIO, Redis
- CI: added MinIO service and separate E2E test step in GitHub Actions

## Test plan
- [x] All 43 tests pass locally
- [ ] CI passes with PostgreSQL + MinIO + Redis services
- [ ] Verify E2E tests run in separate step from unit tests