### PR TITLE
Add publishConfig for public npm access

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -65,5 +65,8 @@
   "bugs": {
     "url": "https://github.com/CePseudoBE/digitaltwin/issues"
   },
-  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme"
+  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -54,5 +54,8 @@
   "bugs": {
     "url": "https://github.com/CePseudoBE/digitaltwin/issues"
   },
-  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme"
+  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -55,5 +55,8 @@
   "bugs": {
     "url": "https://github.com/CePseudoBE/digitaltwin/issues"
   },
-  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme"
+  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -70,5 +70,8 @@
   "bugs": {
     "url": "https://github.com/CePseudoBE/digitaltwin/issues"
   },
-  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme"
+  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -71,5 +71,8 @@
   "bugs": {
     "url": "https://github.com/CePseudoBE/digitaltwin/issues"
   },
-  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme"
+  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/ngsi-ld/package.json
+++ b/packages/ngsi-ld/package.json
@@ -67,5 +67,8 @@
   "bugs": {
     "url": "https://github.com/CePseudoBE/digitaltwin/issues"
   },
-  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme"
+  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -62,5 +62,8 @@
   "bugs": {
     "url": "https://github.com/CePseudoBE/digitaltwin/issues"
   },
-  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme"
+  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -67,5 +67,8 @@
   "bugs": {
     "url": "https://github.com/CePseudoBE/digitaltwin/issues"
   },
-  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme"
+  "homepage": "https://github.com/CePseudoBE/digitaltwin#readme",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
## Summary
- Add `"publishConfig": { "access": "public" }` to all 8 publishable packages
- Scoped packages (`@cepseudo/*`) are private by default on npm, causing 404 on first publish
- e2e is `private: true` and not affected

## Test plan
- [ ] CI passes
- [ ] npm publish succeeds after merge to main