### PR TITLE
test(ngsi-ld): add behavioral test suite for NGSI-LD plugin

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -21,7 +21,8 @@
     "@cepseudo/auth": "workspace:*",
     "@cepseudo/components": "workspace:*",
     "@cepseudo/assets": "workspace:*",
-    "@cepseudo/engine": "workspace:*"
+    "@cepseudo/engine": "workspace:*",
+    "@cepseudo/ngsi-ld": "workspace:*"
   },
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.1002.0",
@@ -29,6 +30,8 @@
     "@japa/assert": "^4.1.0",
     "@japa/runner": "^4.3.0",
     "@testcontainers/redis": "^11.3.1",
+    "bullmq": "^5.0.0",
+    "ioredis": "^5.0.0",
     "jszip": "^3.10.1",
     "pg": "^8.16.0",
     "testcontainers": "^10.0.0",

--- a/packages/e2e/tests/helpers/test_components.ts
+++ b/packages/e2e/tests/helpers/test_components.ts
@@ -5,6 +5,8 @@
  * from component → database → storage and back.
  */
 import { Collector, Harvester, Handler, CustomTableManager } from '@cepseudo/components'
+import { NgsiLdCollector, buildWeatherObserved } from '@cepseudo/ngsi-ld'
+import type { NgsiLdEntity } from '@cepseudo/ngsi-ld'
 import { AssetsManager, TilesetManager, MapManager } from '@cepseudo/assets'
 import { servableEndpoint } from '@cepseudo/shared'
 import type {
@@ -150,6 +152,38 @@ export class E2EMapManager extends MapManager {
             endpoint: 'e2e-maps',
             extension: '.json',
         }
+    }
+}
+
+// ── NgsiLdCollector ──────────────────────────────────────────────────────────
+
+export class NgsiLdWeatherCollector extends NgsiLdCollector {
+    getConfiguration(): CollectorConfiguration {
+        return {
+            name: 'e2e_ngsi_weather',
+            description: 'E2E NGSI-LD weather collector',
+            contentType: 'application/json',
+            endpoint: 'e2e-ngsi-weather',
+        }
+    }
+
+    getSchedule(): string {
+        return '0 */15 * * * *'
+    }
+
+    async collect(): Promise<Buffer> {
+        const data = { temperature: 18.5, humidity: 72, windSpeed: 4.2 }
+        return Buffer.from(JSON.stringify(data))
+    }
+
+    toNgsiLdEntity(data: unknown): NgsiLdEntity {
+        const d = data as { temperature: number; humidity: number; windSpeed: number }
+        return buildWeatherObserved({
+            localId: 'e2e-station-1',
+            temperature: d.temperature,
+            relativeHumidity: d.humidity,
+            windSpeed: d.windSpeed,
+        })
     }
 }
 

--- a/packages/e2e/tests/ngsi_ld.spec.ts
+++ b/packages/e2e/tests/ngsi_ld.spec.ts
@@ -1,0 +1,398 @@
+/**
+ * NGSI-LD E2E Tests
+ *
+ * Starts a real DigitalTwinEngine with the @cepseudo/ngsi-ld plugin loaded
+ * automatically. Verifies entity CRUD, subscription CRUD, and the full
+ * notification flow: collect() → entity cache → subscription match → HTTP POST
+ * to a local webhook receiver.
+ *
+ * Infrastructure: PostgreSQL (subscriptions) + Redis (entity cache, queues)
+ * started via testcontainers (or CI env vars for PG, always testcontainers for Redis).
+ */
+import { test } from '@japa/runner'
+import * as http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { RedisContainer } from '@testcontainers/redis'
+import type { StartedRedisContainer } from '@testcontainers/redis'
+import { DigitalTwinEngine } from '@cepseudo/engine'
+import { LogLevel, Logger } from '@cepseudo/shared'
+import { registerNgsiLd } from '@cepseudo/ngsi-ld'
+import { setupInfrastructure, type E2EInfrastructure } from './helpers/setup.js'
+import { NgsiLdWeatherCollector } from './helpers/test_components.js'
+
+const ENGINE_PORT = 19878
+
+// ── Webhook server helper ─────────────────────────────────────────────────────
+
+interface WebhookServer {
+    url: string
+    waitForCall(timeoutMs?: number): Promise<unknown>
+    stop(): Promise<void>
+}
+
+function startWebhookServer(): Promise<WebhookServer> {
+    return new Promise((resolve, reject) => {
+        const pending: Array<(body: unknown) => void> = []
+        const received: unknown[] = []
+
+        const server = http.createServer((req, res) => {
+            let raw = ''
+            req.on('data', chunk => { raw += chunk })
+            req.on('end', () => {
+                const body = JSON.parse(raw)
+                received.push(body)
+                if (pending.length > 0) {
+                    pending.shift()!(body)
+                }
+                res.writeHead(200, { 'Content-Type': 'application/json' })
+                res.end('{}')
+            })
+        })
+
+        server.listen(0, '127.0.0.1', () => {
+            const { port } = server.address() as AddressInfo
+            resolve({
+                url: `http://127.0.0.1:${port}/webhook`,
+                waitForCall(timeoutMs = 15000): Promise<unknown> {
+                    // If already received, return immediately
+                    if (received.length > 0) return Promise.resolve(received[received.length - 1])
+                    return new Promise((res, rej) => {
+                        const timer = setTimeout(() => rej(new Error('Webhook not called within timeout')), timeoutMs)
+                        pending.push(body => { clearTimeout(timer); res(body) })
+                    })
+                },
+                stop(): Promise<void> {
+                    return new Promise(res => server.close(() => res()))
+                },
+            })
+        })
+
+        server.on('error', reject)
+    })
+}
+
+// ── Test group ────────────────────────────────────────────────────────────────
+
+test.group('NGSI-LD E2E — engine + real HTTP', group => {
+    let infra: E2EInfrastructure
+    let redis: StartedRedisContainer
+    let engine: DigitalTwinEngine
+    let collector: NgsiLdWeatherCollector
+    let baseUrl: string
+    let webhook: WebhookServer
+
+    group.setup(async () => {
+        infra = await setupInfrastructure()
+        redis = await new RedisContainer('redis:7-alpine').start()
+        webhook = await startWebhookServer()
+
+        collector = new NgsiLdWeatherCollector()
+
+        engine = new DigitalTwinEngine({
+            database: infra.db,
+            storage: infra.storage,
+            collectors: [collector],
+            redis: {
+                host: redis.getHost(),
+                port: redis.getMappedPort(6379),
+            },
+            server: { port: ENGINE_PORT },
+            logging: { level: LogLevel.SILENT },
+            queues: { multiQueue: true },
+        })
+
+        // DIGITALTWIN_DISABLE_AUTH is already set to 'true' by setupInfrastructure()
+        await engine.start()
+
+        // Explicitly register the NGSI-LD plugin — pnpm strict isolation prevents
+        // the engine's auto-discovery (dynamic import) from resolving @cepseudo/ngsi-ld
+        // from the engine package's context. The e2e process owns the dependency.
+        const redisConfig = engine.getRedisConfig()
+        await registerNgsiLd({
+            router: engine.getRouter(),
+            db: engine.getDatabase(),
+            redis: redisConfig,
+            components: engine.getAllComponents(),
+            logger: new Logger('ngsi-ld'),
+        })
+
+        baseUrl = `http://localhost:${ENGINE_PORT}`
+    })
+
+    group.teardown(async () => {
+        await webhook.stop()
+        try {
+            await Promise.race([
+                engine.stop(),
+                new Promise((_, reject) => setTimeout(() => reject(new Error('stop timeout')), 5000)),
+            ])
+        } catch { /* ignore */ }
+        await redis.stop()
+        await infra.cleanup()
+    })
+
+    // ── Entity endpoints ──────────────────────────────────────────────────────
+
+    test('POST /ngsi-ld/v1/entities creates entity, GET retrieves it', async ({ assert }) => {
+        const entity = {
+            id: 'urn:ngsi-ld:WeatherObserved:test-post-1',
+            type: 'WeatherObserved',
+            temperature: { type: 'Property', value: 21.0 },
+        }
+
+        const postRes = await fetch(`${baseUrl}/ngsi-ld/v1/entities`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(entity),
+        })
+        assert.equal(postRes.status, 201)
+        assert.include(postRes.headers.get('Location') ?? '', encodeURIComponent(entity.id))
+
+        const getRes = await fetch(`${baseUrl}/ngsi-ld/v1/entities/${encodeURIComponent(entity.id)}`)
+        assert.equal(getRes.status, 200)
+
+        const body = await getRes.json() as Record<string, unknown>
+        assert.equal(body['id'], entity.id)
+        assert.equal(body['type'], entity.type)
+        assert.property(body, '@context')
+    })
+
+    test('GET /ngsi-ld/v1/entities?type= filters by entity type', async ({ assert }) => {
+        await fetch(`${baseUrl}/ngsi-ld/v1/entities`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: 'urn:ngsi-ld:AirQualityObserved:e2e-1', type: 'AirQualityObserved', pm25: { type: 'Property', value: 45 } }),
+        })
+
+        const res = await fetch(`${baseUrl}/ngsi-ld/v1/entities?type=AirQualityObserved`)
+        assert.equal(res.status, 200)
+
+        const body = await res.json() as Array<Record<string, unknown>>
+        assert.isArray(body)
+        assert.isTrue(body.every(e => e['type'] === 'AirQualityObserved'))
+    })
+
+    test('GET /ngsi-ld/v1/entities?q= applies value filter', async ({ assert }) => {
+        await fetch(`${baseUrl}/ngsi-ld/v1/entities`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: 'urn:ngsi-ld:WeatherObserved:q-hot', type: 'WeatherObserved', temperature: { type: 'Property', value: 38 } }),
+        })
+        await fetch(`${baseUrl}/ngsi-ld/v1/entities`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: 'urn:ngsi-ld:WeatherObserved:q-cold', type: 'WeatherObserved', temperature: { type: 'Property', value: 5 } }),
+        })
+
+        const res = await fetch(`${baseUrl}/ngsi-ld/v1/entities?type=WeatherObserved&q=temperature>30`)
+        assert.equal(res.status, 200)
+
+        const body = await res.json() as Array<Record<string, unknown>>
+        const ids = body.map(e => e['id'])
+        assert.include(ids, 'urn:ngsi-ld:WeatherObserved:q-hot')
+        assert.notInclude(ids, 'urn:ngsi-ld:WeatherObserved:q-cold')
+    })
+
+    test('PATCH /ngsi-ld/v1/entities/:id merges attributes', async ({ assert }) => {
+        const id = 'urn:ngsi-ld:WeatherObserved:patch-test'
+        await fetch(`${baseUrl}/ngsi-ld/v1/entities`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id, type: 'WeatherObserved', temperature: { type: 'Property', value: 10 } }),
+        })
+
+        const patchRes = await fetch(`${baseUrl}/ngsi-ld/v1/entities/${encodeURIComponent(id)}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ temperature: { type: 'Property', value: 25 } }),
+        })
+        assert.equal(patchRes.status, 204)
+
+        const getRes = await fetch(`${baseUrl}/ngsi-ld/v1/entities/${encodeURIComponent(id)}`)
+        const body = await getRes.json() as Record<string, { value: unknown }>
+        assert.equal(body['temperature'].value, 25)
+    })
+
+    test('DELETE /ngsi-ld/v1/entities/:id removes entity', async ({ assert }) => {
+        const id = 'urn:ngsi-ld:WeatherObserved:delete-test'
+        await fetch(`${baseUrl}/ngsi-ld/v1/entities`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id, type: 'WeatherObserved' }),
+        })
+
+        const delRes = await fetch(`${baseUrl}/ngsi-ld/v1/entities/${encodeURIComponent(id)}`, { method: 'DELETE' })
+        assert.equal(delRes.status, 204)
+
+        const getRes = await fetch(`${baseUrl}/ngsi-ld/v1/entities/${encodeURIComponent(id)}`)
+        assert.equal(getRes.status, 404)
+    })
+
+    test('GET /ngsi-ld/v1/entities/:id returns 404 for unknown entity', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/ngsi-ld/v1/entities/${encodeURIComponent('urn:ngsi-ld:Unknown:nobody')}`)
+        assert.equal(res.status, 404)
+    })
+
+    test('POST /ngsi-ld/v1/entities missing id returns 400', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/ngsi-ld/v1/entities`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ type: 'WeatherObserved' }),
+        })
+        assert.equal(res.status, 400)
+    })
+
+    // ── Types endpoint ────────────────────────────────────────────────────────
+
+    test('GET /ngsi-ld/v1/types lists entity types in cache', async ({ assert }) => {
+        await fetch(`${baseUrl}/ngsi-ld/v1/entities`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: 'urn:ngsi-ld:ParkingSpot:types-test', type: 'ParkingSpot' }),
+        })
+
+        const res = await fetch(`${baseUrl}/ngsi-ld/v1/types`)
+        assert.equal(res.status, 200)
+
+        const body = await res.json() as { typeList: string[] }
+        assert.include(body.typeList, 'ParkingSpot')
+    })
+
+    // ── Subscription CRUD ─────────────────────────────────────────────────────
+
+    test('POST /ngsi-ld/v1/subscriptions creates subscription', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/ngsi-ld/v1/subscriptions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                entities: [{ type: 'WeatherObserved' }],
+                notification: { endpoint: { uri: webhook.url }, format: 'normalized' },
+            }),
+        })
+        assert.equal(res.status, 201)
+
+        const body = await res.json() as Record<string, unknown>
+        assert.match(String(body['id']), /^[0-9a-f-]{36}$/)
+        assert.isTrue(body['isActive'])
+        assert.include(res.headers.get('Location') ?? '', '/ngsi-ld/v1/subscriptions/')
+    })
+
+    test('GET /ngsi-ld/v1/subscriptions lists subscriptions', async ({ assert }) => {
+        await fetch(`${baseUrl}/ngsi-ld/v1/subscriptions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                name: 'List test sub',
+                entities: [{ type: 'WeatherObserved' }],
+                notification: { endpoint: { uri: webhook.url } },
+            }),
+        })
+
+        const res = await fetch(`${baseUrl}/ngsi-ld/v1/subscriptions`)
+        assert.equal(res.status, 200)
+
+        const body = await res.json() as unknown[]
+        assert.isArray(body)
+        assert.isAbove(body.length, 0)
+    })
+
+    test('PATCH /ngsi-ld/v1/subscriptions/:id updates subscription', async ({ assert }) => {
+        const createRes = await fetch(`${baseUrl}/ngsi-ld/v1/subscriptions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                name: 'Before patch',
+                entities: [{ type: 'WeatherObserved' }],
+                notification: { endpoint: { uri: webhook.url } },
+            }),
+        })
+        const { id } = await createRes.json() as { id: string }
+
+        const patchRes = await fetch(`${baseUrl}/ngsi-ld/v1/subscriptions/${id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: 'After patch' }),
+        })
+        assert.equal(patchRes.status, 204)
+
+        const getRes = await fetch(`${baseUrl}/ngsi-ld/v1/subscriptions/${id}`)
+        const body = await getRes.json() as { name: string }
+        assert.equal(body.name, 'After patch')
+    })
+
+    test('DELETE /ngsi-ld/v1/subscriptions/:id removes subscription', async ({ assert }) => {
+        const createRes = await fetch(`${baseUrl}/ngsi-ld/v1/subscriptions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                entities: [{ type: 'WeatherObserved' }],
+                notification: { endpoint: { uri: webhook.url } },
+            }),
+        })
+        const { id } = await createRes.json() as { id: string }
+
+        const delRes = await fetch(`${baseUrl}/ngsi-ld/v1/subscriptions/${id}`, { method: 'DELETE' })
+        assert.equal(delRes.status, 204)
+
+        const getRes = await fetch(`${baseUrl}/ngsi-ld/v1/subscriptions/${id}`)
+        assert.equal(getRes.status, 404)
+    })
+
+    test('POST /ngsi-ld/v1/subscriptions missing endpoint.uri returns 400', async ({ assert }) => {
+        const res = await fetch(`${baseUrl}/ngsi-ld/v1/subscriptions`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                entities: [{ type: 'WeatherObserved' }],
+                notification: { endpoint: {} },
+            }),
+        })
+        assert.equal(res.status, 400)
+    })
+
+    // ── Full notification flow ─────────────────────────────────────────────────
+
+    test('collect() → entity cached → subscription matched → webhook notified', async ({ assert }) => {
+        // Create a fresh webhook server for this test to get a clean call count
+        const notifyWebhook = await startWebhookServer()
+
+        try {
+            // Create subscription watching WeatherObserved with no throttling
+            const createRes = await fetch(`${baseUrl}/ngsi-ld/v1/subscriptions`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: 'E2E notification test',
+                    entities: [{ type: 'WeatherObserved' }],
+                    notification: {
+                        endpoint: { uri: notifyWebhook.url },
+                        format: 'normalized',
+                    },
+                    throttling: 0,
+                }),
+            })
+            assert.equal(createRes.status, 201)
+
+            // Manually run the collector — triggers the engine event bus
+            await collector.run()
+
+            // Wait for the webhook to receive the notification (up to 15s)
+            const payload = await notifyWebhook.waitForCall(15000) as {
+                type: string
+                subscriptionId: string
+                data: Array<{ type: string; temperature?: { value: number } }>
+            }
+
+            assert.equal(payload.type, 'Notification')
+            assert.isString(payload.subscriptionId)
+            assert.isArray(payload.data)
+            assert.isAbove(payload.data.length, 0)
+
+            const entity = payload.data[0]
+            assert.equal(entity.type, 'WeatherObserved')
+            assert.property(entity, 'temperature')
+        } finally {
+            await notifyWebhook.stop()
+        }
+    })
+})

--- a/packages/ngsi-ld/tests/endpoints_entities.spec.ts
+++ b/packages/ngsi-ld/tests/endpoints_entities.spec.ts
@@ -1,0 +1,317 @@
+import { test } from '@japa/runner'
+import { Redis } from 'ioredis'
+import { RedisContainer } from '@testcontainers/redis'
+import { EntityCache } from '../src/cache/entity_cache.js'
+import { registerEntityEndpoints } from '../src/endpoints/entities.js'
+import type { NgsiLdEntity } from '../src/types/entity.js'
+import { property } from '../src/helpers/property.js'
+import { buildUrn } from '../src/helpers/urn.js'
+import { NGSI_LD_CORE_CONTEXT } from '../src/types/context.js'
+
+// --- MockRouter ---
+
+type RouteHandler = (req: any, res: any) => Promise<void> | void
+
+class MockRouter {
+    private routes = new Map<string, RouteHandler>()
+
+    private reg(method: string, path: string, h: RouteHandler) {
+        this.routes.set(`${method} ${path}`, h)
+    }
+
+    get(path: string, h: RouteHandler) { this.reg('GET', path, h) }
+    post(path: string, h: RouteHandler) { this.reg('POST', path, h) }
+    patch(path: string, h: RouteHandler) { this.reg('PATCH', path, h) }
+    delete(path: string, h: RouteHandler) { this.reg('DELETE', path, h) }
+
+    async invoke(method: string, templatePath: string, req: any, res: any) {
+        const h = this.routes.get(`${method} ${templatePath}`)
+        if (!h) throw new Error(`No handler registered: ${method} ${templatePath}`)
+        await h(req, res)
+    }
+}
+
+// --- Mock req / res factories ---
+
+function makeReq(opts: {
+    body?: unknown
+    params?: Record<string, string>
+    query?: Record<string, string>
+} = {}) {
+    return { body: opts.body ?? {}, params: opts.params ?? {}, query: opts.query ?? {} }
+}
+
+function makeRes() {
+    const res = {
+        statusCode: 200,
+        body: undefined as unknown,
+        resHeaders: {} as Record<string, string>,
+        ended: false,
+        status(code: number) { res.statusCode = code; return res },
+        json(data: unknown) { res.body = data; return res },
+        end() { res.ended = true; return res },
+        setHeader(name: string, value: string) { res.resHeaders[name] = value; return res },
+    }
+    return res
+}
+
+// --- Entity helpers ---
+
+function makeEntity(type: string, localId: string, attrs: Record<string, number | string> = {}): NgsiLdEntity {
+    const entity: NgsiLdEntity = { id: buildUrn(type, localId), type }
+    for (const [key, value] of Object.entries(attrs)) {
+        entity[key] = property(value)
+    }
+    return entity
+}
+
+// --- Tests ---
+
+test.group('Entity endpoints (integration)', group => {
+    let redisContainer: Awaited<ReturnType<ReturnType<typeof RedisContainer.prototype.start>['constructor']>>
+    let redis: Redis
+    let cache: EntityCache
+    let router: MockRouter
+
+    group.each.setup(async () => {
+        redisContainer = await new RedisContainer('redis:7-alpine').start()
+        redis = new Redis({
+            host: (redisContainer as any).getHost(),
+            port: (redisContainer as any).getPort(),
+            maxRetriesPerRequest: null,
+        })
+        cache = new EntityCache(redis)
+        router = new MockRouter()
+        registerEntityEndpoints(router as any, cache, null as any, null as any)
+    })
+
+    group.each.teardown(async () => {
+        await redis.quit()
+        await (redisContainer as any).stop()
+    })
+
+    // GET /ngsi-ld/v1/entities
+
+    test('GET /ngsi-ld/v1/entities returns 200 with empty array when cache is empty', async ({ assert }) => {
+        const req = makeReq({ query: {} })
+        const res = makeRes()
+
+        await router.invoke('GET', '/ngsi-ld/v1/entities', req, res)
+
+        assert.equal(res.statusCode, 200)
+        assert.deepEqual(res.body, [])
+    })
+
+    test('GET /ngsi-ld/v1/entities returns all entities with @context added', async ({ assert }) => {
+        const e1 = makeEntity('AirQualityObserved', 'sensor-1', { pm25: 42 })
+        const e2 = makeEntity('WeatherObserved', 'station-1', { temperature: 15 })
+        await cache.set(e1)
+        await cache.set(e2)
+
+        const req = makeReq({ query: {} })
+        const res = makeRes()
+
+        await router.invoke('GET', '/ngsi-ld/v1/entities', req, res)
+
+        assert.equal(res.statusCode, 200)
+        const body = res.body as NgsiLdEntity[]
+        assert.lengthOf(body, 2)
+        for (const entity of body) {
+            assert.property(entity, '@context')
+            assert.equal(entity['@context'], NGSI_LD_CORE_CONTEXT)
+        }
+    })
+
+    test('GET /ngsi-ld/v1/entities?type=X returns only entities of that type', async ({ assert }) => {
+        const e1 = makeEntity('AirQualityObserved', 'sensor-2', { pm25: 30 })
+        const e2 = makeEntity('WeatherObserved', 'station-2', { temperature: 18 })
+        await cache.set(e1)
+        await cache.set(e2)
+
+        const req = makeReq({ query: { type: 'AirQualityObserved' } })
+        const res = makeRes()
+
+        await router.invoke('GET', '/ngsi-ld/v1/entities', req, res)
+
+        assert.equal(res.statusCode, 200)
+        const body = res.body as NgsiLdEntity[]
+        assert.lengthOf(body, 1)
+        assert.equal(body[0].type, 'AirQualityObserved')
+    })
+
+    test('GET /ngsi-ld/v1/entities?q=pm25>30 returns only matching entities', async ({ assert }) => {
+        const e1 = makeEntity('AirQualityObserved', 'sensor-3', { pm25: 50 })
+        const e2 = makeEntity('AirQualityObserved', 'sensor-4', { pm25: 10 })
+        await cache.set(e1)
+        await cache.set(e2)
+
+        const req = makeReq({ query: { q: 'pm25>30' } })
+        const res = makeRes()
+
+        await router.invoke('GET', '/ngsi-ld/v1/entities', req, res)
+
+        assert.equal(res.statusCode, 200)
+        const body = res.body as NgsiLdEntity[]
+        assert.lengthOf(body, 1)
+        assert.equal(body[0].id, e1.id)
+    })
+
+    test('GET /ngsi-ld/v1/entities with invalid q-filter returns 400', async ({ assert }) => {
+        const req = makeReq({ query: { q: 'invalid!!!' } })
+        const res = makeRes()
+
+        await router.invoke('GET', '/ngsi-ld/v1/entities', req, res)
+
+        assert.equal(res.statusCode, 400)
+        const body = res.body as { type: string }
+        assert.include(body.type, 'BadRequestData')
+    })
+
+    test('GET /ngsi-ld/v1/entities?attrs=pm25 projects entities to only that attribute', async ({ assert }) => {
+        const e1 = makeEntity('AirQualityObserved', 'sensor-5', { pm25: 60, temperature: 22 })
+        await cache.set(e1)
+
+        const req = makeReq({ query: { attrs: 'pm25' } })
+        const res = makeRes()
+
+        await router.invoke('GET', '/ngsi-ld/v1/entities', req, res)
+
+        assert.equal(res.statusCode, 200)
+        const body = res.body as NgsiLdEntity[]
+        assert.lengthOf(body, 1)
+        assert.property(body[0], 'pm25')
+        assert.notProperty(body[0], 'temperature')
+        assert.property(body[0], 'id')
+        assert.property(body[0], 'type')
+        assert.property(body[0], '@context')
+    })
+
+    // POST /ngsi-ld/v1/entities
+
+    test('POST /ngsi-ld/v1/entities with valid body returns 201 and Location header', async ({ assert }) => {
+        const entity = makeEntity('AirQualityObserved', 'sensor-6', { pm25: 33 })
+        const req = makeReq({ body: entity })
+        const res = makeRes()
+
+        await router.invoke('POST', '/ngsi-ld/v1/entities', req, res)
+
+        assert.equal(res.statusCode, 201)
+        assert.isTrue(res.ended)
+        assert.equal(res.resHeaders['Location'], `/ngsi-ld/v1/entities/${encodeURIComponent(entity.id)}`)
+    })
+
+    test('POST /ngsi-ld/v1/entities missing id returns 400', async ({ assert }) => {
+        const req = makeReq({ body: { type: 'AirQualityObserved' } })
+        const res = makeRes()
+
+        await router.invoke('POST', '/ngsi-ld/v1/entities', req, res)
+
+        assert.equal(res.statusCode, 400)
+        const body = res.body as { type: string }
+        assert.include(body.type, 'BadRequestData')
+    })
+
+    test('POST /ngsi-ld/v1/entities missing type returns 400', async ({ assert }) => {
+        const req = makeReq({ body: { id: buildUrn('AirQualityObserved', 'sensor-99') } })
+        const res = makeRes()
+
+        await router.invoke('POST', '/ngsi-ld/v1/entities', req, res)
+
+        assert.equal(res.statusCode, 400)
+        const body = res.body as { type: string }
+        assert.include(body.type, 'BadRequestData')
+    })
+
+    // GET /ngsi-ld/v1/entities/:entityId
+
+    test('GET /ngsi-ld/v1/entities/:entityId returns 200 and entity with @context', async ({ assert }) => {
+        const entity = makeEntity('AirQualityObserved', 'sensor-7', { pm25: 77 })
+        await cache.set(entity)
+
+        const req = makeReq({ params: { entityId: entity.id } })
+        const res = makeRes()
+
+        await router.invoke('GET', '/ngsi-ld/v1/entities/:entityId', req, res)
+
+        assert.equal(res.statusCode, 200)
+        const body = res.body as NgsiLdEntity
+        assert.equal(body.id, entity.id)
+        assert.property(body, '@context')
+    })
+
+    test('GET /ngsi-ld/v1/entities/:entityId with unknown id returns 404', async ({ assert }) => {
+        const req = makeReq({ params: { entityId: buildUrn('AirQualityObserved', 'nobody') } })
+        const res = makeRes()
+
+        await router.invoke('GET', '/ngsi-ld/v1/entities/:entityId', req, res)
+
+        assert.equal(res.statusCode, 404)
+        const body = res.body as { type: string }
+        assert.include(body.type, 'ResourceNotFound')
+    })
+
+    // PATCH /ngsi-ld/v1/entities/:entityId
+
+    test('PATCH /ngsi-ld/v1/entities/:entityId returns 204 and updates the entity in cache', async ({ assert }) => {
+        const entity = makeEntity('AirQualityObserved', 'sensor-8', { pm25: 10 })
+        await cache.set(entity)
+
+        const req = makeReq({
+            params: { entityId: entity.id },
+            body: { pm25: property(99) },
+        })
+        const res = makeRes()
+
+        await router.invoke('PATCH', '/ngsi-ld/v1/entities/:entityId', req, res)
+
+        assert.equal(res.statusCode, 204)
+        assert.isTrue(res.ended)
+
+        const updated = await cache.get(entity.id)
+        assert.isNotNull(updated)
+        assert.deepEqual(updated!.pm25, property(99))
+    })
+
+    test('PATCH /ngsi-ld/v1/entities/:entityId with unknown id returns 404', async ({ assert }) => {
+        const req = makeReq({
+            params: { entityId: buildUrn('AirQualityObserved', 'ghost') },
+            body: { pm25: property(1) },
+        })
+        const res = makeRes()
+
+        await router.invoke('PATCH', '/ngsi-ld/v1/entities/:entityId', req, res)
+
+        assert.equal(res.statusCode, 404)
+        const body = res.body as { type: string }
+        assert.include(body.type, 'ResourceNotFound')
+    })
+
+    // DELETE /ngsi-ld/v1/entities/:entityId
+
+    test('DELETE /ngsi-ld/v1/entities/:entityId returns 204 and removes entity from cache', async ({ assert }) => {
+        const entity = makeEntity('AirQualityObserved', 'sensor-9', { pm25: 5 })
+        await cache.set(entity)
+
+        const req = makeReq({ params: { entityId: entity.id } })
+        const res = makeRes()
+
+        await router.invoke('DELETE', '/ngsi-ld/v1/entities/:entityId', req, res)
+
+        assert.equal(res.statusCode, 204)
+        assert.isTrue(res.ended)
+
+        const gone = await cache.get(entity.id)
+        assert.isNull(gone)
+    })
+
+    test('DELETE /ngsi-ld/v1/entities/:entityId with unknown id returns 404', async ({ assert }) => {
+        const req = makeReq({ params: { entityId: buildUrn('AirQualityObserved', 'phantom') } })
+        const res = makeRes()
+
+        await router.invoke('DELETE', '/ngsi-ld/v1/entities/:entityId', req, res)
+
+        assert.equal(res.statusCode, 404)
+        const body = res.body as { type: string }
+        assert.include(body.type, 'ResourceNotFound')
+    })
+})

--- a/packages/ngsi-ld/tests/endpoints_subscriptions.spec.ts
+++ b/packages/ngsi-ld/tests/endpoints_subscriptions.spec.ts
@@ -1,0 +1,286 @@
+import { test } from '@japa/runner'
+import { KyselyDatabaseAdapter } from '@cepseudo/database'
+import { SubscriptionStore } from '../src/subscriptions/subscription_store.js'
+import { registerSubscriptionEndpoints } from '../src/endpoints/subscriptions.js'
+import type { Subscription, SubscriptionCreate } from '../src/types/subscription.js'
+import type { SubscriptionCache } from '../src/subscriptions/subscription_cache.js'
+
+const dataResolver = async (_url: string): Promise<Buffer> => Buffer.alloc(0)
+
+// --- MockRouter ---
+
+type RouteHandler = (req: any, res: any) => Promise<void> | void
+
+class MockRouter {
+    private routes = new Map<string, RouteHandler>()
+
+    private reg(method: string, path: string, h: RouteHandler) {
+        this.routes.set(`${method} ${path}`, h)
+    }
+
+    get(path: string, h: RouteHandler) { this.reg('GET', path, h) }
+    post(path: string, h: RouteHandler) { this.reg('POST', path, h) }
+    patch(path: string, h: RouteHandler) { this.reg('PATCH', path, h) }
+    delete(path: string, h: RouteHandler) { this.reg('DELETE', path, h) }
+
+    async invoke(method: string, templatePath: string, req: any, res: any) {
+        const h = this.routes.get(`${method} ${templatePath}`)
+        if (!h) throw new Error(`No handler registered: ${method} ${templatePath}`)
+        await h(req, res)
+    }
+}
+
+// --- Mock req / res factories ---
+
+function makeReq(opts: {
+    body?: unknown
+    params?: Record<string, string>
+    query?: Record<string, string>
+} = {}) {
+    return { body: opts.body ?? {}, params: opts.params ?? {}, query: opts.query ?? {} }
+}
+
+function makeRes() {
+    const res = {
+        statusCode: 200,
+        body: undefined as unknown,
+        resHeaders: {} as Record<string, string>,
+        ended: false,
+        status(code: number) { res.statusCode = code; return res },
+        json(data: unknown) { res.body = data; return res },
+        end() { res.ended = true; return res },
+        setHeader(name: string, value: string) { res.resHeaders[name] = value; return res },
+    }
+    return res
+}
+
+// --- In-memory MockSubscriptionCache ---
+
+class MockSubscriptionCache implements SubscriptionCache {
+    private readonly subs = new Map<string, Subscription>()
+
+    async warmup(subscriptions: Subscription[]): Promise<void> {
+        for (const sub of subscriptions) {
+            await this.add(sub)
+        }
+    }
+
+    async add(sub: Subscription): Promise<void> {
+        this.subs.set(sub.id, sub)
+    }
+
+    async update(sub: Subscription): Promise<void> {
+        this.subs.set(sub.id, sub)
+    }
+
+    async remove(id: string): Promise<void> {
+        this.subs.delete(id)
+    }
+
+    async getById(id: string): Promise<Subscription | null> {
+        return this.subs.get(id) ?? null
+    }
+
+    async getIdsByType(type: string): Promise<string[]> {
+        return [...this.subs.values()]
+            .filter(s => s.entityTypes.includes(type))
+            .map(s => s.id)
+    }
+
+    async getByType(type: string): Promise<Subscription[]> {
+        return [...this.subs.values()].filter(
+            s => s.isActive && s.entityTypes.includes(type)
+        )
+    }
+
+    async updateLastNotified(id: string, at: string): Promise<void> {
+        const sub = this.subs.get(id)
+        if (sub) {
+            this.subs.set(id, { ...sub, lastNotificationAt: at })
+        }
+    }
+}
+
+// --- SubscriptionCreate helpers ---
+
+function makeInput(overrides: Partial<SubscriptionCreate> = {}): SubscriptionCreate {
+    return {
+        notification: {
+            endpoint: { uri: 'https://example.com/notify' },
+            format: 'normalized',
+        },
+        entities: [{ type: 'AirQualityObserved' }],
+        ...overrides,
+    }
+}
+
+// --- Tests ---
+
+test.group('Subscription endpoints', group => {
+    let db: KyselyDatabaseAdapter
+    let store: SubscriptionStore
+    let cache: MockSubscriptionCache
+    let router: MockRouter
+
+    group.each.setup(async () => {
+        db = await KyselyDatabaseAdapter.forSQLite({ filename: ':memory:', enableForeignKeys: false }, dataResolver)
+        store = new SubscriptionStore(db)
+        await store.runMigration()
+        cache = new MockSubscriptionCache()
+        router = new MockRouter()
+        registerSubscriptionEndpoints(router as any, store, cache as unknown as SubscriptionCache)
+    })
+
+    group.each.teardown(async () => {
+        await db.close()
+    })
+
+    // POST /ngsi-ld/v1/subscriptions
+
+    test('POST /ngsi-ld/v1/subscriptions with valid body returns 201 and Location header', async ({ assert }) => {
+        const req = makeReq({ body: makeInput() })
+        const res = makeRes()
+
+        await router.invoke('POST', '/ngsi-ld/v1/subscriptions', req, res)
+
+        assert.equal(res.statusCode, 201)
+        const body = res.body as Subscription
+        assert.isString(body.id)
+        assert.isTrue(body.isActive)
+        assert.include(res.resHeaders['Location'], body.id)
+    })
+
+    test('POST /ngsi-ld/v1/subscriptions missing notification.endpoint.uri returns 400', async ({ assert }) => {
+        const req = makeReq({
+            body: {
+                notification: { endpoint: {} },
+                entities: [{ type: 'AirQualityObserved' }],
+            },
+        })
+        const res = makeRes()
+
+        await router.invoke('POST', '/ngsi-ld/v1/subscriptions', req, res)
+
+        assert.equal(res.statusCode, 400)
+        const body = res.body as { type: string }
+        assert.include(body.type, 'BadRequestData')
+    })
+
+    test('POST /ngsi-ld/v1/subscriptions with null body returns 400', async ({ assert }) => {
+        const req = makeReq({ body: null })
+        const res = makeRes()
+
+        await router.invoke('POST', '/ngsi-ld/v1/subscriptions', req, res)
+
+        assert.equal(res.statusCode, 400)
+        const body = res.body as { type: string }
+        assert.include(body.type, 'BadRequestData')
+    })
+
+    // GET /ngsi-ld/v1/subscriptions
+
+    test('GET /ngsi-ld/v1/subscriptions returns 200 and array of subscriptions', async ({ assert }) => {
+        await store.create(makeInput({ name: 'sub-a' }))
+        await store.create(makeInput({ name: 'sub-b' }))
+
+        const req = makeReq()
+        const res = makeRes()
+
+        await router.invoke('GET', '/ngsi-ld/v1/subscriptions', req, res)
+
+        assert.equal(res.statusCode, 200)
+        const body = res.body as Subscription[]
+        assert.isArray(body)
+        assert.lengthOf(body, 2)
+    })
+
+    // GET /ngsi-ld/v1/subscriptions/:subscriptionId
+
+    test('GET /ngsi-ld/v1/subscriptions/:subscriptionId returns 200 and the subscription', async ({ assert }) => {
+        const sub = await store.create(makeInput({ name: 'find-me' }))
+
+        const req = makeReq({ params: { subscriptionId: sub.id } })
+        const res = makeRes()
+
+        await router.invoke('GET', '/ngsi-ld/v1/subscriptions/:subscriptionId', req, res)
+
+        assert.equal(res.statusCode, 200)
+        const body = res.body as Subscription
+        assert.equal(body.id, sub.id)
+        assert.equal(body.name, 'find-me')
+    })
+
+    test('GET /ngsi-ld/v1/subscriptions/:subscriptionId with unknown id returns 404', async ({ assert }) => {
+        const req = makeReq({ params: { subscriptionId: '00000000-0000-0000-0000-000000000000' } })
+        const res = makeRes()
+
+        await router.invoke('GET', '/ngsi-ld/v1/subscriptions/:subscriptionId', req, res)
+
+        assert.equal(res.statusCode, 404)
+        const body = res.body as { type: string }
+        assert.include(body.type, 'ResourceNotFound')
+    })
+
+    // PATCH /ngsi-ld/v1/subscriptions/:subscriptionId
+
+    test('PATCH /ngsi-ld/v1/subscriptions/:subscriptionId returns 204 and updates name in store', async ({ assert }) => {
+        const sub = await store.create(makeInput({ name: 'original' }))
+
+        const req = makeReq({
+            params: { subscriptionId: sub.id },
+            body: { name: 'updated' },
+        })
+        const res = makeRes()
+
+        await router.invoke('PATCH', '/ngsi-ld/v1/subscriptions/:subscriptionId', req, res)
+
+        assert.equal(res.statusCode, 204)
+        assert.isTrue(res.ended)
+
+        const persisted = await store.findById(sub.id)
+        assert.isNotNull(persisted)
+        assert.equal(persisted!.name, 'updated')
+    })
+
+    test('PATCH /ngsi-ld/v1/subscriptions/:subscriptionId with unknown id returns 404', async ({ assert }) => {
+        const req = makeReq({
+            params: { subscriptionId: '00000000-0000-0000-0000-000000000000' },
+            body: { name: 'irrelevant' },
+        })
+        const res = makeRes()
+
+        await router.invoke('PATCH', '/ngsi-ld/v1/subscriptions/:subscriptionId', req, res)
+
+        assert.equal(res.statusCode, 404)
+        const body = res.body as { type: string }
+        assert.include(body.type, 'ResourceNotFound')
+    })
+
+    // DELETE /ngsi-ld/v1/subscriptions/:subscriptionId
+
+    test('DELETE /ngsi-ld/v1/subscriptions/:subscriptionId returns 204 and soft-deletes the subscription', async ({ assert }) => {
+        const sub = await store.create(makeInput())
+
+        const req = makeReq({ params: { subscriptionId: sub.id } })
+        const res = makeRes()
+
+        await router.invoke('DELETE', '/ngsi-ld/v1/subscriptions/:subscriptionId', req, res)
+
+        assert.equal(res.statusCode, 204)
+        assert.isTrue(res.ended)
+
+        const gone = await store.findById(sub.id)
+        assert.isNull(gone)
+    })
+
+    test('DELETE /ngsi-ld/v1/subscriptions/:subscriptionId with unknown id returns 404', async ({ assert }) => {
+        const req = makeReq({ params: { subscriptionId: '00000000-0000-0000-0000-000000000000' } })
+        const res = makeRes()
+
+        await router.invoke('DELETE', '/ngsi-ld/v1/subscriptions/:subscriptionId', req, res)
+
+        assert.equal(res.statusCode, 404)
+        const body = res.body as { type: string }
+        assert.include(body.type, 'ResourceNotFound')
+    })
+})

--- a/packages/ngsi-ld/tests/helpers.spec.ts
+++ b/packages/ngsi-ld/tests/helpers.spec.ts
@@ -2,95 +2,121 @@ import { test } from '@japa/runner'
 import { property, geoProperty, relationship } from '../src/helpers/property.js'
 import { buildUrn, parseUrn } from '../src/helpers/urn.js'
 import { isNgsiLdCollector, isNgsiLdHarvester } from '../src/components/type_guards.js'
+import { parseQ, evaluateQ } from '../src/subscriptions/q_parser.js'
+import type { NgsiLdEntity } from '../src/types/entity.js'
 
-test.group('property()', () => {
-    test('creates a Property with the given value', ({ assert }) => {
-        const p = property(42)
-        assert.equal(p.type, 'Property')
-        assert.equal(p.value, 42)
+// ── property() ───────────────────────────────────────────────────────────────
+// Tested through q-filter evaluation — the primary consumer of Property values.
+
+test.group('property() — q-filter evaluation', () => {
+    test('a numeric property is correctly evaluated by a q-filter', ({ assert }) => {
+        const entity: NgsiLdEntity = {
+            id: buildUrn('AirQualityObserved', 'sensor-1'),
+            type: 'AirQualityObserved',
+            pm25: property(42),
+        }
+
+        assert.isTrue(evaluateQ(parseQ('pm25>30'), entity))
+        assert.isFalse(evaluateQ(parseQ('pm25>50'), entity))
     })
 
-    test('passes through optional metadata', ({ assert }) => {
-        const p = property('hello', { observedAt: '2026-01-01T00:00:00Z', unitCode: 'CEL' })
-        assert.equal(p.type, 'Property')
-        assert.equal(p.value, 'hello')
-        assert.equal(p.observedAt, '2026-01-01T00:00:00Z')
-        assert.equal(p.unitCode, 'CEL')
+    test('a string property is correctly evaluated by equality filter', ({ assert }) => {
+        const entity: NgsiLdEntity = {
+            id: buildUrn('Device', 'gateway-1'),
+            type: 'Device',
+            status: property('online'),
+        }
+
+        assert.isTrue(evaluateQ(parseQ('status=="online"'), entity))
+        assert.isFalse(evaluateQ(parseQ('status=="offline"'), entity))
     })
 
-    test('handles boolean values', ({ assert }) => {
-        const p = property(true)
-        assert.equal(p.type, 'Property')
-        assert.equal(p.value, true)
+    test('a property with observedAt metadata survives JSON round-trip', ({ assert }) => {
+        const original = property(22.5, { observedAt: '2026-01-01T00:00:00Z', unitCode: 'CEL' })
+        const roundTripped = JSON.parse(JSON.stringify(original))
+
+        assert.equal(roundTripped.value, 22.5)
+        assert.equal(roundTripped.observedAt, '2026-01-01T00:00:00Z')
+        assert.equal(roundTripped.unitCode, 'CEL')
     })
 
-    test('handles array values', ({ assert }) => {
-        const p = property(['a', 'b'])
-        assert.deepEqual(p.value, ['a', 'b'])
-    })
+    test('a null property causes equality filter to return false', ({ assert }) => {
+        const entity: NgsiLdEntity = {
+            id: buildUrn('Device', 'sensor-null'),
+            type: 'Device',
+            status: property(null),
+        }
 
-    test('handles null value', ({ assert }) => {
-        const p = property(null)
-        assert.equal(p.type, 'Property')
-        assert.isNull(p.value)
-    })
-})
-
-test.group('geoProperty()', () => {
-    test('creates a GeoProperty with Point geometry', ({ assert }) => {
-        const geo = geoProperty({ type: 'Point', coordinates: [4.35, 50.85] })
-        assert.equal(geo.type, 'GeoProperty')
-        assert.deepEqual(geo.value, { type: 'Point', coordinates: [4.35, 50.85] })
-    })
-
-    test('passes through optional metadata', ({ assert }) => {
-        const geo = geoProperty({ type: 'Point', coordinates: [0, 0] }, { observedAt: '2026-01-01T00:00:00Z' })
-        assert.equal(geo.observedAt, '2026-01-01T00:00:00Z')
-    })
-})
-
-test.group('relationship()', () => {
-    test('creates a Relationship with the given URN', ({ assert }) => {
-        const rel = relationship('urn:ngsi-ld:Building:42')
-        assert.equal(rel.type, 'Relationship')
-        assert.equal(rel.object, 'urn:ngsi-ld:Building:42')
-    })
-
-    test('passes through optional metadata', ({ assert }) => {
-        const rel = relationship('urn:ngsi-ld:Building:42', { observedAt: '2026-01-01T00:00:00Z' })
-        assert.equal(rel.observedAt, '2026-01-01T00:00:00Z')
+        // null value does not equal 'ok' — missing/null attributes fail equality
+        assert.isFalse(evaluateQ(parseQ('status=="ok"'), entity))
     })
 })
 
-test.group('buildUrn()', () => {
-    test('builds a correct NGSI-LD URN', ({ assert }) => {
+// ── geoProperty() ────────────────────────────────────────────────────────────
+// Tested through entity storage — geoProperties live inside entities that are
+// serialized to and from Redis (JSON round-trip).
+
+test.group('geoProperty() — entity storage round-trip', () => {
+    test('a geo property preserves geometry after JSON round-trip', ({ assert }) => {
+        const entity: NgsiLdEntity = {
+            id: buildUrn('ParkingSpot', 'lot-1'),
+            type: 'ParkingSpot',
+            location: geoProperty({ type: 'Point', coordinates: [4.35, 50.85] }),
+        }
+
+        const stored = JSON.parse(JSON.stringify(entity))
+        assert.deepEqual(stored.location.value, { type: 'Point', coordinates: [4.35, 50.85] })
+    })
+
+    test('geo property metadata survives JSON round-trip', ({ assert }) => {
+        const entity: NgsiLdEntity = {
+            id: buildUrn('ParkingSpot', 'lot-2'),
+            type: 'ParkingSpot',
+            location: geoProperty(
+                { type: 'Point', coordinates: [0, 0] },
+                { observedAt: '2026-01-01T00:00:00Z' }
+            ),
+        }
+
+        const stored = JSON.parse(JSON.stringify(entity))
+        assert.equal(stored.location.observedAt, '2026-01-01T00:00:00Z')
+    })
+})
+
+// ── relationship() ───────────────────────────────────────────────────────────
+
+test.group('relationship() — entity storage round-trip', () => {
+    test('a relationship preserves its target URN after JSON round-trip', ({ assert }) => {
+        const entity: NgsiLdEntity = {
+            id: buildUrn('Device', 'sensor-1'),
+            type: 'Device',
+            installedIn: relationship('urn:ngsi-ld:Building:headquarters'),
+        }
+
+        const stored = JSON.parse(JSON.stringify(entity))
+        assert.equal(stored.installedIn.object, 'urn:ngsi-ld:Building:headquarters')
+    })
+
+    test('relationship metadata survives JSON round-trip', ({ assert }) => {
+        const entity: NgsiLdEntity = {
+            id: buildUrn('Device', 'sensor-2'),
+            type: 'Device',
+            installedIn: relationship(
+                'urn:ngsi-ld:Building:headquarters',
+                { observedAt: '2026-03-01T00:00:00Z' }
+            ),
+        }
+
+        const stored = JSON.parse(JSON.stringify(entity))
+        assert.equal(stored.installedIn.observedAt, '2026-03-01T00:00:00Z')
+    })
+})
+
+// ── buildUrn / parseUrn ───────────────────────────────────────────────────────
+
+test.group('URN helpers', () => {
+    test('buildUrn produces a valid NGSI-LD URN', ({ assert }) => {
         assert.equal(buildUrn('AirQualityObserved', 'sensor-42'), 'urn:ngsi-ld:AirQualityObserved:sensor-42')
-    })
-
-    test('handles localId with colons', ({ assert }) => {
-        assert.equal(buildUrn('Device', 'zone:1:sensor:2'), 'urn:ngsi-ld:Device:zone:1:sensor:2')
-    })
-})
-
-test.group('parseUrn()', () => {
-    test('parses a valid NGSI-LD URN', ({ assert }) => {
-        const result = parseUrn('urn:ngsi-ld:AirQualityObserved:sensor-42')
-        assert.equal(result.type, 'AirQualityObserved')
-        assert.equal(result.localId, 'sensor-42')
-    })
-
-    test('handles localId containing colons', ({ assert }) => {
-        const result = parseUrn('urn:ngsi-ld:Device:zone:1:sensor:2')
-        assert.equal(result.type, 'Device')
-        assert.equal(result.localId, 'zone:1:sensor:2')
-    })
-
-    test('throws on invalid format (no ngsi-ld prefix)', ({ assert }) => {
-        assert.throws(() => parseUrn('urn:other:Foo:bar'), /Invalid NGSI-LD URN/)
-    })
-
-    test('throws on completely wrong format', ({ assert }) => {
-        assert.throws(() => parseUrn('not-a-urn'), /Invalid NGSI-LD URN/)
     })
 
     test('buildUrn and parseUrn are inverse operations', ({ assert }) => {
@@ -99,44 +125,51 @@ test.group('parseUrn()', () => {
         assert.equal(parsed.type, 'WeatherObserved')
         assert.equal(parsed.localId, 'station-99')
     })
+
+    test('localId containing colons round-trips correctly', ({ assert }) => {
+        const urn = buildUrn('Device', 'zone:1:sensor:2')
+        const parsed = parseUrn(urn)
+        assert.equal(parsed.localId, 'zone:1:sensor:2')
+    })
+
+    test('parseUrn throws on invalid format', ({ assert }) => {
+        assert.throws(() => parseUrn('not-a-urn'), /Invalid NGSI-LD URN/)
+        assert.throws(() => parseUrn('urn:other:Foo:bar'), /Invalid NGSI-LD URN/)
+    })
 })
 
-test.group('type guards', () => {
-    test('isNgsiLdCollector returns false for plain object', ({ assert }) => {
-        assert.isFalse(isNgsiLdCollector({}))
-    })
+// ── Type guards ───────────────────────────────────────────────────────────────
 
-    test('isNgsiLdCollector returns false for null', ({ assert }) => {
-        assert.isFalse(isNgsiLdCollector(null))
-    })
-
-    test('isNgsiLdCollector returns true for duck-typed object', ({ assert }) => {
-        const fakeCollector = {
-            toNgsiLdEntity: () => ({}),
+test.group('NGSI-LD type guards', () => {
+    test('a component implementing toNgsiLdEntity is recognized as NGSI-LD capable', ({ assert }) => {
+        const ngsiCollector = {
+            toNgsiLdEntity: () => ({} as NgsiLdEntity),
             collect: async () => Buffer.from(''),
             getSchedule: () => '* * * * * *',
         }
-        assert.isTrue(isNgsiLdCollector(fakeCollector))
-    })
-
-    test('isNgsiLdHarvester returns false for plain object', ({ assert }) => {
-        assert.isFalse(isNgsiLdHarvester({}))
-    })
-
-    test('isNgsiLdHarvester returns true for duck-typed object', ({ assert }) => {
-        const fakeHarvester = {
-            toNgsiLdEntity: () => ({}),
+        const ngsiHarvester = {
+            toNgsiLdEntity: () => ({} as NgsiLdEntity),
             harvest: async () => Buffer.from(''),
             getUserConfiguration: () => ({}),
         }
-        assert.isTrue(isNgsiLdHarvester(fakeHarvester))
+
+        assert.isTrue(isNgsiLdCollector(ngsiCollector))
+        assert.isTrue(isNgsiLdHarvester(ngsiHarvester))
     })
 
-    test('isNgsiLdCollector returns false when toNgsiLdEntity is missing', ({ assert }) => {
-        const noNgsi = {
+    test('a standard component without toNgsiLdEntity is not treated as NGSI-LD capable', ({ assert }) => {
+        const plainCollector = {
             collect: async () => Buffer.from(''),
             getSchedule: () => '* * * * * *',
         }
-        assert.isFalse(isNgsiLdCollector(noNgsi))
+        const plainHarvester = {
+            harvest: async () => Buffer.from(''),
+            getUserConfiguration: () => ({}),
+        }
+
+        assert.isFalse(isNgsiLdCollector(plainCollector))
+        assert.isFalse(isNgsiLdHarvester(plainHarvester))
+        assert.isFalse(isNgsiLdCollector(null))
+        assert.isFalse(isNgsiLdCollector({}))
     })
 })

--- a/packages/ngsi-ld/tests/notification_sender.spec.ts
+++ b/packages/ngsi-ld/tests/notification_sender.spec.ts
@@ -1,0 +1,106 @@
+import { test } from '@japa/runner'
+import { randomUUID } from 'node:crypto'
+import { enqueueNotification } from '../src/notifications/notification_sender.js'
+import type { Subscription } from '../src/types/subscription.js'
+import type { NgsiLdEntity } from '../src/types/entity.js'
+import type { NotificationJobData } from '../src/types/notification.js'
+import { property } from '../src/helpers/property.js'
+import { buildUrn } from '../src/helpers/urn.js'
+
+function makeSub(overrides: Partial<Subscription> = {}): Subscription {
+    return {
+        id: randomUUID(),
+        entityTypes: ['AirQualityObserved'],
+        notificationEndpoint: 'https://example.com/notify',
+        notificationFormat: 'normalized',
+        throttling: 0,
+        isActive: true,
+        timesSent: 0,
+        timesFailed: 0,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        ...overrides,
+    }
+}
+
+function makeEntity(attrs: Record<string, number | string> = {}): NgsiLdEntity {
+    const entity: NgsiLdEntity = {
+        id: buildUrn('AirQualityObserved', 'sensor-1'),
+        type: 'AirQualityObserved',
+    }
+    for (const [key, value] of Object.entries(attrs)) {
+        entity[key] = property(value)
+    }
+    return entity
+}
+
+function makeMockQueue() {
+    const jobs: NotificationJobData[] = []
+    return {
+        jobs,
+        async add(_name: string, data: NotificationJobData) {
+            jobs.push(data)
+        },
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.group('enqueueNotification — attribute projection', () => {
+    test('a subscription without attribute filter delivers all entity attributes', async ({ assert }) => {
+        const queue = makeMockQueue()
+        const entity = makeEntity({ pm25: 42, temperature: 20, no2: 15 })
+
+        await enqueueNotification(makeSub(), entity, queue as any)
+
+        const delivered = queue.jobs[0].entity
+        assert.property(delivered, 'pm25')
+        assert.property(delivered, 'temperature')
+        assert.property(delivered, 'no2')
+    })
+
+    test('a subscription with notificationAttrs delivers only those attributes', async ({ assert }) => {
+        const queue = makeMockQueue()
+        const entity = makeEntity({ pm25: 42, temperature: 20 })
+
+        await enqueueNotification(makeSub({ notificationAttrs: ['pm25'] }), entity, queue as any)
+
+        const delivered = queue.jobs[0].entity
+        assert.property(delivered, 'pm25')
+        assert.notProperty(delivered, 'temperature')
+    })
+
+    test('id and type are always delivered regardless of attribute filter', async ({ assert }) => {
+        const queue = makeMockQueue()
+        const entity = makeEntity({ pm25: 42 })
+
+        await enqueueNotification(makeSub({ notificationAttrs: ['pm25'] }), entity, queue as any)
+
+        const delivered = queue.jobs[0].entity
+        assert.equal(delivered.id, entity.id)
+        assert.equal(delivered.type, entity.type)
+    })
+
+    test('requesting an attribute absent from the entity does not include it and does not error', async ({ assert }) => {
+        const queue = makeMockQueue()
+        const entity = makeEntity({ pm25: 42 })
+
+        await assert.doesNotReject(() =>
+            enqueueNotification(makeSub({ notificationAttrs: ['pm25', 'no2'] }), entity, queue as any)
+        )
+
+        const delivered = queue.jobs[0].entity
+        assert.property(delivered, 'pm25')
+        assert.notProperty(delivered, 'no2')
+    })
+})
+
+test.group('enqueueNotification — delivery conditions', () => {
+    test('subscriptions with no endpoint are not queued for delivery', async ({ assert }) => {
+        const queue = makeMockQueue()
+
+        await enqueueNotification(makeSub({ notificationEndpoint: '' }), makeEntity({ pm25: 42 }), queue as any)
+
+        assert.lengthOf(queue.jobs, 0)
+    })
+})

--- a/packages/ngsi-ld/tests/notification_worker.spec.ts
+++ b/packages/ngsi-ld/tests/notification_worker.spec.ts
@@ -1,0 +1,231 @@
+import { test } from '@japa/runner'
+import { randomUUID } from 'node:crypto'
+import * as http from 'node:http'
+import { Queue, Worker } from 'bullmq'
+import { Redis } from 'ioredis'
+import { RedisContainer } from '@testcontainers/redis'
+import { startNotificationWorker } from '../src/notifications/notification_worker.js'
+import type { NotificationJobData, NotificationPayload } from '../src/types/notification.js'
+import type { Subscription } from '../src/types/subscription.js'
+import type { NgsiLdEntity } from '../src/types/entity.js'
+import { property } from '../src/helpers/property.js'
+import { buildUrn } from '../src/helpers/urn.js'
+
+const QUEUE_NAME = 'ngsi-ld-notifications'
+
+// --- Helpers ---
+
+function makeSub(endpoint: string, overrides: Partial<Subscription> = {}): Subscription {
+    return {
+        id: randomUUID(),
+        entityTypes: ['AirQualityObserved'],
+        notificationEndpoint: endpoint,
+        notificationFormat: 'normalized',
+        throttling: 0,
+        isActive: true,
+        timesSent: 0,
+        timesFailed: 0,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        ...overrides,
+    }
+}
+
+function makeEntity(): NgsiLdEntity {
+    return {
+        id: buildUrn('AirQualityObserved', 'sensor-1'),
+        type: 'AirQualityObserved',
+        pm25: property(55),
+    }
+}
+
+// --- Mock store and cache ---
+
+interface RecordedNotification {
+    id: string
+    success: boolean
+    at: string
+}
+
+function makeMockStore() {
+    const calls: RecordedNotification[] = []
+    return {
+        calls,
+        async recordNotification(id: string, success: boolean, at: string): Promise<void> {
+            calls.push({ id, success, at })
+        },
+    }
+}
+
+interface RecordedCacheUpdate {
+    id: string
+    at: string
+}
+
+function makeMockCache() {
+    const calls: RecordedCacheUpdate[] = []
+    return {
+        calls,
+        async updateLastNotified(id: string, at: string): Promise<void> {
+            calls.push({ id, at })
+        },
+    }
+}
+
+function makeMockLogger() {
+    return {
+        info(_msg: string) {},
+        warn(_msg: string) {},
+    }
+}
+
+// --- HTTP webhook helpers ---
+
+interface WebhookRequest {
+    method: string
+    headers: http.IncomingHttpHeaders
+    body: string
+}
+
+function startWebhookServer(statusCode: number): Promise<{ server: http.Server; requests: WebhookRequest[]; url: string }> {
+    return new Promise(resolve => {
+        const requests: WebhookRequest[] = []
+        const server = http.createServer((req, res) => {
+            let body = ''
+            req.on('data', chunk => { body += chunk })
+            req.on('end', () => {
+                requests.push({ method: req.method ?? '', headers: req.headers, body })
+                res.writeHead(statusCode)
+                res.end()
+            })
+        })
+        server.listen(0, '127.0.0.1', () => {
+            const addr = server.address() as { port: number }
+            resolve({ server, requests, url: `http://127.0.0.1:${addr.port}/webhook` })
+        })
+    })
+}
+
+function waitForEvent(emitter: { on: (event: string, cb: (...args: any[]) => void) => void }, event: string, timeoutMs = 10000): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`Timed out waiting for '${event}' event`)), timeoutMs)
+        emitter.on(event, () => {
+            clearTimeout(timer)
+            resolve()
+        })
+    })
+}
+
+// --- Tests ---
+
+test.group('notification worker (integration)', group => {
+    let redisContainer: Awaited<ReturnType<ReturnType<typeof RedisContainer.prototype.start>['constructor']>>
+    let redis: Redis
+    let queue: Queue<NotificationJobData>
+    let worker: Worker<NotificationJobData>
+    let webhookServer: http.Server
+    let webhookRequests: WebhookRequest[]
+    let webhookUrl: string
+    let store: ReturnType<typeof makeMockStore>
+    let cache: ReturnType<typeof makeMockCache>
+
+    group.each.setup(async () => {
+        redisContainer = await new RedisContainer('redis:7-alpine').start()
+        const host = (redisContainer as any).getHost() as string
+        const port = (redisContainer as any).getPort() as number
+
+        redis = new Redis({ host, port, maxRetriesPerRequest: null })
+
+        const connection = { host, port }
+        queue = new Queue<NotificationJobData>(QUEUE_NAME, { connection })
+        store = makeMockStore()
+        cache = makeMockCache()
+        const logger = makeMockLogger()
+        worker = startNotificationWorker(connection, store as any, cache as any, logger as any)
+    })
+
+    group.each.teardown(async () => {
+        await worker.close()
+        await queue.close()
+        if (webhookServer) {
+            await new Promise<void>(resolve => webhookServer.close(() => resolve()))
+        }
+        await redis.quit()
+        await (redisContainer as any).stop()
+    })
+
+    test('delivers notification via POST and records success', async ({ assert }) => {
+        const webhook = await startWebhookServer(200)
+        webhookServer = webhook.server
+        webhookRequests = webhook.requests
+        webhookUrl = webhook.url
+
+        const sub = makeSub(webhookUrl)
+        const entity = makeEntity()
+        const notificationId = randomUUID()
+        const notifiedAt = new Date().toISOString()
+
+        const jobData: NotificationJobData = {
+            subscription: sub,
+            entity,
+            notificationId,
+            notifiedAt,
+        }
+
+        await queue.add('notify', jobData, { attempts: 1 })
+        await waitForEvent(worker, 'completed')
+
+        // Webhook received the POST
+        assert.lengthOf(webhookRequests, 1)
+        assert.equal(webhookRequests[0].method, 'POST')
+
+        // Content-Type header was application/ld+json
+        assert.equal(webhookRequests[0].headers['content-type'], 'application/ld+json')
+
+        // Payload is a valid NotificationPayload
+        const payload = JSON.parse(webhookRequests[0].body) as NotificationPayload
+        assert.equal(payload.type, 'Notification')
+        assert.equal(payload.subscriptionId, sub.id)
+        assert.lengthOf(payload.data, 1)
+        assert.equal(payload.data[0].id, entity.id)
+
+        // store.recordNotification called with success = true
+        assert.lengthOf(store.calls, 1)
+        assert.equal(store.calls[0].id, sub.id)
+        assert.isTrue(store.calls[0].success)
+        assert.equal(store.calls[0].at, notifiedAt)
+
+        // cache.updateLastNotified called
+        assert.lengthOf(cache.calls, 1)
+        assert.equal(cache.calls[0].id, sub.id)
+        assert.equal(cache.calls[0].at, notifiedAt)
+    })
+
+    test('records failure when webhook returns HTTP 500', async ({ assert }) => {
+        const webhook = await startWebhookServer(500)
+        webhookServer = webhook.server
+        webhookRequests = webhook.requests
+        webhookUrl = webhook.url
+
+        const sub = makeSub(webhookUrl)
+        const entity = makeEntity()
+        const notificationId = randomUUID()
+        const notifiedAt = new Date().toISOString()
+
+        const jobData: NotificationJobData = {
+            subscription: sub,
+            entity,
+            notificationId,
+            notifiedAt,
+        }
+
+        // Use attempts: 1 so we do not wait for retries
+        await queue.add('notify', jobData, { attempts: 1 })
+        await waitForEvent(worker, 'failed')
+
+        // store.recordNotification called with success = false
+        assert.lengthOf(store.calls, 1)
+        assert.equal(store.calls[0].id, sub.id)
+        assert.isFalse(store.calls[0].success)
+    })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
       '@cepseudo/engine':
         specifier: workspace:*
         version: link:../engine
+      '@cepseudo/ngsi-ld':
+        specifier: workspace:*
+        version: link:../ngsi-ld
       '@cepseudo/shared':
         specifier: workspace:*
         version: link:../shared
@@ -360,6 +363,12 @@ importers:
       '@testcontainers/redis':
         specifier: ^11.3.1
         version: 11.11.0
+      bullmq:
+        specifier: ^5.0.0
+        version: 5.66.5
+      ioredis:
+        specifier: ^5.0.0
+        version: 5.9.1
       jszip:
         specifier: ^3.10.1
         version: 3.10.1


### PR DESCRIPTION
Add unit, integration, and e2e tests for the @cepseudo/ngsi-ld package, covering all previously untested paths with a behavioral focus.

Unit tests (@cepseudo/ngsi-ld):
- notification_sender: attribute projection and delivery conditions
- notification_worker: full delivery flow with Redis testcontainer + mock webhook
- endpoints_entities: all HTTP entity endpoints via mock router/req/res
- endpoints_subscriptions: all HTTP subscription endpoints with SQLite store
- helpers: property/geoProperty/relationship tested through q-filter evaluation and JSON round-trips; type guards tested by system-level recognition

E2E tests (@cepseudo/e2e):
- ngsi_ld: full engine integration — entity CRUD, subscription CRUD, types endpoint, and the complete collect → cache → match → webhook delivery flow against real PostgreSQL, Redis, and a local HTTP receiver